### PR TITLE
attribute: initial commit

### DIFF
--- a/align.go
+++ b/align.go
@@ -31,11 +31,9 @@ func nlaAlign(len int) int {
 	return ((len) + nlaAlignTo - 1) & ^(nlaAlignTo - 1)
 }
 
-// #define NLA_HDRLEN              ((int) NLA_ALIGN(sizeof(struct nlattr)))
-var nlaHeaderLen = nlaAlign(int(unsafe.Sizeof(attribute{})))
+// Because this package's Attribute type contains a byte slice, unsafe.Sizeof
+// can't be used to determine the correct length.
+const sizeofAttribute = 4
 
-// TODO(mdlayher): find home for Attribute type
-type attribute struct {
-	Length uint16
-	Type   uint16
-}
+// #define NLA_HDRLEN              ((int) NLA_ALIGN(sizeof(struct nlattr)))
+var nlaHeaderLen = nlaAlign(sizeofAttribute)

--- a/attribute.go
+++ b/attribute.go
@@ -1,0 +1,115 @@
+package netlink
+
+import (
+	"errors"
+)
+
+var (
+	// errInvalidAttribute specifies if an Attribute's length is incorrect.
+	errInvalidAttribute = errors.New("invalid attribute; length too short or too large")
+)
+
+// An Attribute is a netlink attribute.  Attributes are packed and unpacked
+// to and from the Data field of Message for some netlink protocol families.
+type Attribute struct {
+	// Length of an Attribute, including this field and Type.
+	Length uint16
+
+	// The type of this Attribute, typically matched to a constant.
+	Type uint16
+
+	// An arbitrary payload which is specified by Type.
+	Data []byte
+}
+
+// MarshalBinary marshals an Attribute into a byte slice.
+func (a Attribute) MarshalBinary() ([]byte, error) {
+	if int(a.Length) < nlaHeaderLen {
+		return nil, errInvalidAttribute
+	}
+
+	b := make([]byte, nlaAlign(int(a.Length)))
+
+	PutUint16(b[0:2], a.Length)
+	PutUint16(b[2:4], a.Type)
+	copy(b[4:], a.Data)
+
+	return b, nil
+}
+
+// UnmarshalBinary unmarshals the contents of a byte slice into an Attribute.
+func (a *Attribute) UnmarshalBinary(b []byte) error {
+	if len(b) < nlaHeaderLen {
+		return errInvalidAttribute
+	}
+
+	a.Length = Uint16(b[0:2])
+	a.Type = Uint16(b[2:4])
+
+	if nlaAlign(int(a.Length)) > len(b) {
+		return errInvalidAttribute
+	}
+
+	if a.Length == 0 {
+		a.Data = make([]byte, 0)
+	}
+	if a.Length > 0 {
+		a.Data = make([]byte, len(b[4:a.Length]))
+		copy(a.Data, b[4:a.Length])
+	}
+
+	return nil
+}
+
+// MarshalAttributes packs a slice of Attributes into a single byte slice.
+// In most cases, the Length field of each Attribute should be set to 0, so it
+// can be calculated and populated automatically for each Attribute.
+func MarshalAttributes(attrs []Attribute) ([]byte, error) {
+	var c int
+	for _, a := range attrs {
+		c += nlaAlign(len(a.Data))
+	}
+
+	b := make([]byte, 0, c)
+	for _, a := range attrs {
+		if a.Length == 0 {
+			a.Length = uint16(nlaHeaderLen + len(a.Data))
+		}
+
+		ab, err := a.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+
+		b = append(b, ab...)
+	}
+
+	return b, nil
+}
+
+// UnmarshalAttributes unpacks a slice of Attributes from a single byte slice.
+func UnmarshalAttributes(b []byte) ([]Attribute, error) {
+	var attrs []Attribute
+	var i int
+	for {
+		if len(b[i:]) == 0 {
+			break
+		}
+
+		var a Attribute
+		if err := (&a).UnmarshalBinary(b[i:]); err != nil {
+			return nil, err
+		}
+
+		if a.Length == 0 {
+			i += nlaHeaderLen
+			continue
+		}
+
+		i += nlaAlign(int(a.Length))
+
+		attrs = append(attrs, a)
+	}
+
+	return attrs, nil
+}

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -1,0 +1,364 @@
+package netlink
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestMarshalAttributes(t *testing.T) {
+	tests := []struct {
+		name  string
+		attrs []Attribute
+		b     []byte
+		err   error
+	}{
+		{
+			name: "one attribute, short length",
+			attrs: []Attribute{{
+				Length: 3,
+				Type:   1,
+			}},
+			err: errInvalidAttribute,
+		},
+		{
+			name: "one attribute, no data",
+			attrs: []Attribute{{
+				Length: 4,
+				Type:   1,
+				Data:   make([]byte, 0),
+			}},
+			b: []byte{
+				0x04, 0x00,
+				0x01, 0x00,
+			},
+		},
+		{
+			name: "one attribute, no data, length calculated",
+			attrs: []Attribute{{
+				Type: 1,
+				Data: make([]byte, 0),
+			}},
+			b: []byte{
+				0x04, 0x00,
+				0x01, 0x00,
+			},
+		},
+		{
+			name: "one attribute, padded",
+			attrs: []Attribute{{
+				Length: 5,
+				Type:   1,
+				Data:   []byte{0xff},
+			}},
+			b: []byte{
+				0x05, 0x00,
+				0x01, 0x00,
+				0xff, 0x00, 0x00, 0x00,
+			},
+		},
+		{
+			name: "one attribute, padded, length calculated",
+			attrs: []Attribute{{
+				Type: 1,
+				Data: []byte{0xff},
+			}},
+			b: []byte{
+				0x05, 0x00,
+				0x01, 0x00,
+				0xff, 0x00, 0x00, 0x00,
+			},
+		},
+		{
+			name: "one attribute, aligned",
+			attrs: []Attribute{{
+				Length: 8,
+				Type:   2,
+				Data:   []byte{0xaa, 0xbb, 0xcc, 0xdd},
+			}},
+			b: []byte{
+				0x08, 0x00,
+				0x02, 0x00,
+				0xaa, 0xbb, 0xcc, 0xdd,
+			},
+		},
+		{
+			name: "one attribute, aligned, length calculated",
+			attrs: []Attribute{{
+				Type: 2,
+				Data: []byte{0xaa, 0xbb, 0xcc, 0xdd},
+			}},
+			b: []byte{
+				0x08, 0x00,
+				0x02, 0x00,
+				0xaa, 0xbb, 0xcc, 0xdd,
+			},
+		},
+		{
+			name: "multiple attributes",
+			attrs: []Attribute{
+				{
+					Length: 5,
+					Type:   1,
+					Data:   []byte{0xff},
+				},
+				{
+					Length: 8,
+					Type:   2,
+					Data:   []byte{0xaa, 0xbb, 0xcc, 0xdd},
+				},
+				{
+					Length: 4,
+					Type:   3,
+					Data:   make([]byte, 0),
+				},
+				{
+					Length: 16,
+					Type:   4,
+					Data: []byte{
+						0x11, 0x11, 0x11, 0x11,
+						0x22, 0x22, 0x22, 0x22,
+						0x33, 0x33, 0x33, 0x33,
+					},
+				},
+			},
+			b: []byte{
+				// 1
+				0x05, 0x00,
+				0x01, 0x00,
+				0xff, 0x00, 0x00, 0x00,
+				// 2
+				0x08, 0x00,
+				0x02, 0x00,
+				0xaa, 0xbb, 0xcc, 0xdd,
+				// 3
+				0x04, 0x00,
+				0x03, 0x00,
+				// 4
+				0x10, 0x00,
+				0x04, 0x00,
+				0x11, 0x11, 0x11, 0x11,
+				0x22, 0x22, 0x22, 0x22,
+				0x33, 0x33, 0x33, 0x33,
+			},
+		},
+		{
+			name: "multiple attributes, length calculated",
+			attrs: []Attribute{
+				{
+					Type: 1,
+					Data: []byte{0xff},
+				},
+				{
+					Type: 2,
+					Data: []byte{0xaa, 0xbb, 0xcc, 0xdd},
+				},
+				{
+					Type: 3,
+					Data: make([]byte, 0),
+				},
+				{
+					Type: 4,
+					Data: []byte{
+						0x11, 0x11, 0x11, 0x11,
+						0x22, 0x22, 0x22, 0x22,
+						0x33, 0x33, 0x33, 0x33,
+					},
+				},
+			},
+			b: []byte{
+				// 1
+				0x05, 0x00,
+				0x01, 0x00,
+				0xff, 0x00, 0x00, 0x00,
+				// 2
+				0x08, 0x00,
+				0x02, 0x00,
+				0xaa, 0xbb, 0xcc, 0xdd,
+				// 3
+				0x04, 0x00,
+				0x03, 0x00,
+				// 4
+				0x10, 0x00,
+				0x04, 0x00,
+				0x11, 0x11, 0x11, 0x11,
+				0x22, 0x22, 0x22, 0x22,
+				0x33, 0x33, 0x33, 0x33,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := MarshalAttributes(tt.attrs)
+
+			if want, got := tt.err, err; want != got {
+				t.Fatalf("unexpected error:\n- want: %v\n-  got: %v",
+					want, got)
+			}
+			if err != nil {
+				return
+			}
+
+			if want, got := tt.b, b; !bytes.Equal(want, got) {
+				t.Fatalf("unexpected bytes:\n- want: [%# x]\n-  got: [%# x]",
+					want, got)
+			}
+		})
+	}
+}
+
+func TestUnmarshalAttributes(t *testing.T) {
+	tests := []struct {
+		name  string
+		b     []byte
+		attrs []Attribute
+		err   error
+	}{
+		{
+			name: "empty slice",
+		},
+		{
+			name: "short slice",
+			b:    make([]byte, 3),
+			err:  errInvalidAttribute,
+		},
+		{
+			name: "length too short (<4 bytes)",
+			b: []byte{
+				0x03, 0x00,
+				0x00,
+			},
+			err: errInvalidAttribute,
+		},
+		{
+			name: "length too long",
+			b: []byte{
+				0xff, 0xff,
+				0x00, 0x00,
+			},
+			err: errInvalidAttribute,
+		},
+		{
+			name: "one attribute, not aligned",
+			b: []byte{
+				0x05, 0x00,
+				0x01, 0x00,
+				0xff,
+			},
+			err: errInvalidAttribute,
+		},
+		{
+			name: "no attributes, length 0",
+			b: []byte{
+				0x00, 0x00,
+				0x00, 0x00,
+			},
+		},
+		{
+			name: "one attribute, no data",
+			b: []byte{
+				0x04, 0x00,
+				0x01, 0x00,
+			},
+			attrs: []Attribute{{
+				Length: 4,
+				Type:   1,
+				Data:   make([]byte, 0),
+			}},
+		},
+		{
+			name: "one attribute, padded",
+			b: []byte{
+				0x05, 0x00,
+				0x01, 0x00,
+				0xff, 0x00, 0x00, 0x00,
+			},
+			attrs: []Attribute{{
+				Length: 5,
+				Type:   1,
+				Data:   []byte{0xff},
+			}},
+		},
+		{
+			name: "one attribute, aligned",
+			b: []byte{
+				0x08, 0x00,
+				0x02, 0x00,
+				0xaa, 0xbb, 0xcc, 0xdd,
+			},
+			attrs: []Attribute{{
+				Length: 8,
+				Type:   2,
+				Data:   []byte{0xaa, 0xbb, 0xcc, 0xdd},
+			}},
+		},
+		{
+			name: "multiple attributes",
+			b: []byte{
+				// 1
+				0x05, 0x00,
+				0x01, 0x00,
+				0xff, 0x00, 0x00, 0x00,
+				// 2
+				0x08, 0x00,
+				0x02, 0x00,
+				0xaa, 0xbb, 0xcc, 0xdd,
+				// 3
+				0x04, 0x00,
+				0x03, 0x00,
+				// 4
+				0x10, 0x00,
+				0x04, 0x00,
+				0x11, 0x11, 0x11, 0x11,
+				0x22, 0x22, 0x22, 0x22,
+				0x33, 0x33, 0x33, 0x33,
+			},
+			attrs: []Attribute{
+				{
+					Length: 5,
+					Type:   1,
+					Data:   []byte{0xff},
+				},
+				{
+					Length: 8,
+					Type:   2,
+					Data:   []byte{0xaa, 0xbb, 0xcc, 0xdd},
+				},
+				{
+					Length: 4,
+					Type:   3,
+					Data:   make([]byte, 0),
+				},
+				{
+					Length: 16,
+					Type:   4,
+					Data: []byte{
+						0x11, 0x11, 0x11, 0x11,
+						0x22, 0x22, 0x22, 0x22,
+						0x33, 0x33, 0x33, 0x33,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attrs, err := UnmarshalAttributes(tt.b)
+
+			if want, got := tt.err, err; want != got {
+				t.Fatalf("unexpected error:\n- want: %v\n-  got: %v",
+					want, got)
+			}
+			if err != nil {
+				return
+			}
+
+			if want, got := tt.attrs, attrs; !reflect.DeepEqual(want, got) {
+				t.Fatalf("unexpected attributes:\n- want: %v\n-  got: %v",
+					want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Works as intended for marshaling and unmarshaling a slice of Attributes to and from a generic netlink "get family" request.