### PR TITLE
nlenc: initial commit, move integer encoding/decoding functions

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -2,6 +2,8 @@ package netlink
 
 import (
 	"errors"
+
+	"github.com/mdlayher/netlink/nlenc"
 )
 
 var (
@@ -30,8 +32,8 @@ func (a Attribute) MarshalBinary() ([]byte, error) {
 
 	b := make([]byte, nlaAlign(int(a.Length)))
 
-	PutUint16(b[0:2], a.Length)
-	PutUint16(b[2:4], a.Type)
+	nlenc.PutUint16(b[0:2], a.Length)
+	nlenc.PutUint16(b[2:4], a.Type)
 	copy(b[4:], a.Data)
 
 	return b, nil
@@ -43,8 +45,8 @@ func (a *Attribute) UnmarshalBinary(b []byte) error {
 		return errInvalidAttribute
 	}
 
-	a.Length = Uint16(b[0:2])
-	a.Type = Uint16(b[2:4])
+	a.Length = nlenc.Uint16(b[0:2])
+	a.Type = nlenc.Uint16(b[2:4])
 
 	if nlaAlign(int(a.Length)) > len(b) {
 		return errInvalidAttribute

--- a/conn_linux_test.go
+++ b/conn_linux_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"syscall"
 	"testing"
+
+	"github.com/mdlayher/netlink/nlenc"
 )
 
 func TestLinuxConn_bind(t *testing.T) {
@@ -194,7 +196,7 @@ func TestLinuxConnIntegration(t *testing.T) {
 
 	m := msgs[0]
 
-	if want, got := 0, int(Uint32(m.Data[0:4])); want != got {
+	if want, got := 0, int(nlenc.Uint32(m.Data[0:4])); want != got {
 		t.Fatalf("unexpected error code:\n- want: %v\n-  got: %v", want, got)
 	}
 

--- a/message.go
+++ b/message.go
@@ -2,6 +2,8 @@ package netlink
 
 import (
 	"errors"
+
+	"github.com/mdlayher/netlink/nlenc"
 )
 
 // Various errors which may occur when attempting to marshal or unmarshal
@@ -122,11 +124,11 @@ func (m Message) MarshalBinary() ([]byte, error) {
 
 	b := make([]byte, ml)
 
-	PutUint32(b[0:4], m.Header.Length)
-	PutUint16(b[4:6], uint16(m.Header.Type))
-	PutUint16(b[6:8], uint16(m.Header.Flags))
-	PutUint32(b[8:12], m.Header.Sequence)
-	PutUint32(b[12:16], m.Header.PID)
+	nlenc.PutUint32(b[0:4], m.Header.Length)
+	nlenc.PutUint16(b[4:6], uint16(m.Header.Type))
+	nlenc.PutUint16(b[6:8], uint16(m.Header.Flags))
+	nlenc.PutUint32(b[8:12], m.Header.Sequence)
+	nlenc.PutUint32(b[12:16], m.Header.PID)
 	copy(b[16:], m.Data)
 
 	return b, nil
@@ -142,15 +144,15 @@ func (m *Message) UnmarshalBinary(b []byte) error {
 	}
 
 	// Don't allow misleading length
-	m.Header.Length = Uint32(b[0:4])
+	m.Header.Length = nlenc.Uint32(b[0:4])
 	if int(m.Header.Length) != len(b) {
 		return errShortMessage
 	}
 
-	m.Header.Type = HeaderType(Uint16(b[4:6]))
-	m.Header.Flags = HeaderFlags(Uint16(b[6:8]))
-	m.Header.Sequence = Uint32(b[8:12])
-	m.Header.PID = Uint32(b[12:16])
+	m.Header.Type = HeaderType(nlenc.Uint16(b[4:6]))
+	m.Header.Flags = HeaderFlags(nlenc.Uint16(b[6:8]))
+	m.Header.Sequence = nlenc.Uint32(b[8:12])
+	m.Header.PID = nlenc.Uint32(b[12:16])
 	m.Data = b[16:]
 
 	return nil
@@ -169,7 +171,7 @@ func checkMessage(m Message) error {
 		return errShortErrorMessage
 	}
 
-	if c := getInt32(m.Data[0:4]); c != success {
+	if c := nlenc.Int32(m.Data[0:4]); c != success {
 		// Error code is a negative integer, convert it into
 		// an OS-specific system call error
 		return newError(-1 * int(c))

--- a/nlenc/doc.go
+++ b/nlenc/doc.go
@@ -1,0 +1,3 @@
+// Package nlenc implements encoding and decoding functions for netlink
+// messages and attributes.
+package nlenc

--- a/nlenc/int.go
+++ b/nlenc/int.go
@@ -1,4 +1,4 @@
-package netlink
+package nlenc
 
 import (
 	"fmt"
@@ -45,13 +45,11 @@ func Uint32(b []byte) uint32 {
 	return *(*uint32)(unsafe.Pointer(&b[0]))
 }
 
-// getInt32 decodes an int32 from b using the host machine's native endianness.
-// If b is not exactly 4 bytes in length, getInt32 will panic.
-//
-// getInt32 is named as such to prevent collision with the built-in int32 type.
-func getInt32(b []byte) int32 {
+// Int32 decodes an int32 from b using the host machine's native endianness.
+// If b is not exactly 4 bytes in length, Int32 will panic.
+func Int32(b []byte) int32 {
 	if l := len(b); l != 4 {
-		panic(fmt.Sprintf("getInt32: unexpected byte slice length: %d", l))
+		panic(fmt.Sprintf("Int32: unexpected byte slice length: %d", l))
 	}
 
 	return *(*int32)(unsafe.Pointer(&b[0]))

--- a/nlenc/int_test.go
+++ b/nlenc/int_test.go
@@ -1,4 +1,4 @@
-package netlink
+package nlenc
 
 import (
 	"bytes"
@@ -72,14 +72,14 @@ func TestUintPanic(t *testing.T) {
 			name: "short get signed 32",
 			b:    make([]byte, 3),
 			fn: func(b []byte) {
-				getInt32(b)
+				Int32(b)
 			},
 		},
 		{
 			name: "long get signed 32",
 			b:    make([]byte, 5),
 			fn: func(b []byte) {
-				getInt32(b)
+				Int32(b)
 			},
 		},
 	}
@@ -192,7 +192,7 @@ func TestUint32(t *testing.T) {
 	}
 }
 
-func Test_getInt32(t *testing.T) {
+func TestInt32(t *testing.T) {
 	tests := []struct {
 		b []byte
 		v int32
@@ -233,7 +233,7 @@ func Test_getInt32(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("0x%04x", tt.v), func(t *testing.T) {
-			v := getInt32(tt.b)
+			v := Int32(tt.b)
 
 			if want, got := tt.v, v; want != got {
 				t.Fatalf("unexpected integer:\n- want: 0x%04x\n-  got: 0x%04x",


### PR DESCRIPTION
These functions are unrelated to netlink sockets, so I think it's best to move them to another package and add additional functions there, like string/bytes encoding and maybe even attributes later.