### PR TITLE
nlenc: add Uint{16,32,64}Bytes helpers

### DIFF
--- a/nlenc/int.go
+++ b/nlenc/int.go
@@ -74,3 +74,30 @@ func Int32(b []byte) int32 {
 
 	return *(*int32)(unsafe.Pointer(&b[0]))
 }
+
+// Uint16Bytes encodes a uint16 into a newly-allocated byte slice using the
+// host machine's native endianness.  It is a shortcut for allocating a new
+// byte slice and filling it using PutUint16.
+func Uint16Bytes(v uint16) []byte {
+	b := make([]byte, 2)
+	PutUint16(b, v)
+	return b
+}
+
+// Uint32Bytes encodes a uint32 into a newly-allocated byte slice using the
+// host machine's native endianness.  It is a shortcut for allocating a new
+// byte slice and filling it using PutUint32.
+func Uint32Bytes(v uint32) []byte {
+	b := make([]byte, 4)
+	PutUint32(b, v)
+	return b
+}
+
+// Uint64Bytes encodes a uint64 into a newly-allocated byte slice using the
+// host machine's native endianness.  It is a shortcut for allocating a new
+// byte slice and filling it using PutUint64.
+func Uint64Bytes(v uint64) []byte {
+	b := make([]byte, 8)
+	PutUint64(b, v)
+	return b
+}

--- a/nlenc/int_test.go
+++ b/nlenc/int_test.go
@@ -165,6 +165,13 @@ func TestUint16(t *testing.T) {
 				t.Fatalf("unexpected integer:\n- want: 0x%04x\n-  got: 0x%04x",
 					want, got)
 			}
+
+			b = Uint16Bytes(tt.v)
+
+			if want, got := tt.b, b; !bytes.Equal(want, got) {
+				t.Fatalf("unexpected bytes:\n- want: [%# x]\n-  got: [%# x]",
+					want, got)
+			}
 		})
 	}
 }
@@ -214,6 +221,13 @@ func TestUint32(t *testing.T) {
 
 			if want, got := tt.v, v; want != got {
 				t.Fatalf("unexpected integer:\n- want: 0x%04x\n-  got: 0x%04x",
+					want, got)
+			}
+
+			b = Uint32Bytes(tt.v)
+
+			if want, got := tt.b, b; !bytes.Equal(want, got) {
+				t.Fatalf("unexpected bytes:\n- want: [%# x]\n-  got: [%# x]",
 					want, got)
 			}
 		})
@@ -273,6 +287,13 @@ func TestUint64(t *testing.T) {
 
 			if want, got := tt.v, v; want != got {
 				t.Fatalf("unexpected integer:\n- want: 0x%04x\n-  got: 0x%04x",
+					want, got)
+			}
+
+			b = Uint64Bytes(tt.v)
+
+			if want, got := tt.b, b; !bytes.Equal(want, got) {
+				t.Fatalf("unexpected bytes:\n- want: [%# x]\n-  got: [%# x]",
 					want, got)
 			}
 		})


### PR DESCRIPTION
This occurs frequently enough that @jsimonetti even made helpers for it in his `rtnetlink` package.  I use it a lot as well, so let's just put it in `nlenc` and be done with it.