### PR TITLE
netlink: add {Join,Leave}Group using setsockopt on Linux

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -32,6 +32,8 @@ type osConn interface {
 	Close() error
 	Send(m Message) error
 	Receive() ([]Message, error)
+	JoinGroup(group uint32) error
+	LeaveGroup(group uint32) error
 }
 
 // Dial dials a connection to netlink, using the specified protocol number.
@@ -177,6 +179,16 @@ func (c *Conn) receive() ([]Message, error) {
 	}
 
 	return append(msgs, mmsgs...), nil
+}
+
+// JoinGroup joins a netlink multicast group by its ID.
+func (c *Conn) JoinGroup(group uint32) error {
+	return c.c.JoinGroup(group)
+}
+
+// LeaveGroup leaves a netlink multicast group by its ID.
+func (c *Conn) LeaveGroup(group uint32) error {
+	return c.c.LeaveGroup(group)
 }
 
 // nextSequence atomically increments Conn's sequence number and returns

--- a/conn_others.go
+++ b/conn_others.go
@@ -39,6 +39,16 @@ func (c *conn) Close() error {
 	return errUnimplemented
 }
 
+// JoinGroup always returns an error.
+func (c *conn) JoinGroup(group uint32) error {
+	return errUnimplemented
+}
+
+// LeaveGroup always returns an error.
+func (c *conn) LeaveGroup(group uint32) error {
+	return errUnimplemented
+}
+
 // newError always returns an error.
 func newError(errno int) error {
 	return errUnimplemented

--- a/conn_others_test.go
+++ b/conn_others_test.go
@@ -34,4 +34,14 @@ func TestOthersConnUnimplemented(t *testing.T) {
 		t.Fatalf("unexpected error during c.Close:\n- want: %v\n-  got: %v",
 			want, got)
 	}
+
+	if got := c.JoinGroup(0); want != got {
+		t.Fatalf("unexpected error during c.JoinGroup:\n- want: %v\n-  got: %v",
+			want, got)
+	}
+
+	if got := c.LeaveGroup(0); want != got {
+		t.Fatalf("unexpected error during c.LeaveGroup:\n- want: %v\n-  got: %v",
+			want, got)
+	}
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -353,8 +353,12 @@ func (c *testOSConn) Receive() ([]Message, error) {
 	return c.receive[c.calls], nil
 }
 
+var _ osConn = &noopConn{}
+
 type noopConn struct{}
 
-func (c *noopConn) Close() error                 { return nil }
-func (c *noopConn) Send(m Message) error         { return nil }
-func (c *noopConn) Receives() ([]Message, error) { return nil, nil }
+func (c *noopConn) Close() error                  { return nil }
+func (c *noopConn) Send(m Message) error          { return nil }
+func (c *noopConn) Receive() ([]Message, error)   { return nil, nil }
+func (c *noopConn) JoinGroup(group uint32) error  { return nil }
+func (c *noopConn) LeaveGroup(group uint32) error { return nil }

--- a/sockopt_linux.go
+++ b/sockopt_linux.go
@@ -1,0 +1,26 @@
+// +build linux,!386
+
+package netlink
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// setsockopt provides access to the setsockopt syscall.
+func setsockopt(fd, level, name int, v unsafe.Pointer, l uint32) error {
+	_, _, errno := syscall.Syscall6(
+		syscall.SYS_SETSOCKOPT,
+		uintptr(fd),
+		uintptr(level),
+		uintptr(name),
+		uintptr(v),
+		uintptr(l),
+		0,
+	)
+	if errno != 0 {
+		return error(errno)
+	}
+
+	return nil
+}

--- a/sockopt_linux_386.go
+++ b/sockopt_linux_386.go
@@ -1,0 +1,36 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux,386
+
+package raw
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const (
+	sysSETSOCKOPT = 0xe
+)
+
+func socketcall(call int, a0, a1, a2, a3, a4, a5 uintptr) (int, syscall.Errno)
+
+// setsockopt provides access to the setsockopt syscall.
+func setsockopt(fd, level, name int, v unsafe.Pointer, l uint32) error {
+	_, errno := socketcall(
+		sysSETSOCKOPT,
+		uintptr(fd),
+		uintptr(level),
+		uintptr(name),
+		uintptr(v),
+		uintptr(l),
+		0,
+	)
+	if errno != 0 {
+		return error(errno)
+	}
+
+	return nil
+}

--- a/sockopt_linux_386.s
+++ b/sockopt_linux_386.s
@@ -1,0 +1,6 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+TEXT	·socketcall(SB),4,$0-36
+	JMP	syscall·socketcall(SB)


### PR DESCRIPTION
Borrowed the `setsockopt()` magic from my raw sockets project.  Seems to work fine on Linux.  Thinking about doing an integration test but I didn't like how it went when I tried to integrate it into our existing one.  I'm sure we'll come up with something.

Fixes #29 .