### PR TITLE
genetlink: add Conn.{Join,Leave}Group

### DIFF
--- a/genetlink/conn.go
+++ b/genetlink/conn.go
@@ -23,6 +23,8 @@ var _ conn = &netlink.Conn{}
 // A conn is a netlink connection, which can be swapped for tests.
 type conn interface {
 	Close() error
+	JoinGroup(group uint32) error
+	LeaveGroup(group uint32) error
 	Send(m netlink.Message) (netlink.Message, error)
 	Receive() ([]netlink.Message, error)
 }
@@ -53,6 +55,16 @@ func newConn(c conn) *Conn {
 // Close closes the connection.
 func (c *Conn) Close() error {
 	return c.c.Close()
+}
+
+// JoinGroup joins a netlink multicast group by its ID.
+func (c *Conn) JoinGroup(group uint32) error {
+	return c.c.JoinGroup(group)
+}
+
+// LeaveGroup leaves a netlink multicast group by its ID.
+func (c *Conn) LeaveGroup(group uint32) error {
+	return c.c.LeaveGroup(group)
 }
 
 // Send sends a single Message to netlink, wrapping it in a netlink.Message

--- a/genetlink/conn_test.go
+++ b/genetlink/conn_test.go
@@ -180,9 +180,13 @@ func (c *testNetlinkConn) Receive() ([]netlink.Message, error) {
 	return c.receive, nil
 }
 
+var _ conn = &noopConn{}
+
 type noopConn struct{}
 
 func (c *noopConn) Close() error                                    { return nil }
+func (c *noopConn) JoinGroup(group uint32) error                    { return nil }
+func (c *noopConn) LeaveGroup(group uint32) error                   { return nil }
 func (c *noopConn) Send(m netlink.Message) (netlink.Message, error) { return netlink.Message{}, nil }
 func (c *noopConn) Receive() ([]netlink.Message, error)             { return nil, nil }
 


### PR DESCRIPTION
Not a whole lot to test here at the moment.  Need to do some better integration tests with multicast groups in the future.