### PR TITLE
netlink: use getsockname to assign Conn PID

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -16,17 +16,19 @@ func TestConnExecute(t *testing.T) {
 		},
 	}
 
+	pid := uint32(os.Getpid())
+
 	replies := []Message{{
 		Header: Header{
 			Type:     HeaderTypeError,
 			Sequence: 1,
-			PID:      uint32(os.Getpid()),
+			PID:      pid,
 		},
 		// Error code "success", no need to echo request back in this test
 		Data: make([]byte, 4),
 	}}
 
-	c, tc := testConn(t)
+	c, tc := testConn(t, pid)
 	tc.receive = [][]Message{replies}
 
 	msgs, err := c.Execute(req)
@@ -37,6 +39,7 @@ func TestConnExecute(t *testing.T) {
 	// Fill in fields for comparison
 	req.Header.Length = uint32(nlmsgAlign(nlmsgLength(0)))
 	req.Header.Sequence = 1
+	req.Header.PID = pid
 
 	if want, got := req, tc.send; !reflect.DeepEqual(want, got) {
 		t.Fatalf("unexpected request:\n- want: %#v\n-  got: %#v",
@@ -49,7 +52,7 @@ func TestConnExecute(t *testing.T) {
 }
 
 func TestConnSend(t *testing.T) {
-	c, tc := testConn(t)
+	c, tc := testConn(t, 0)
 
 	// Let Conn.Send populate length, sequence, PID
 	m := Message{}
@@ -92,178 +95,8 @@ func TestConnSend(t *testing.T) {
 	}
 }
 
-func TestConnReceiveLockFirstPID(t *testing.T) {
-	const pid = uint32(100)
-
-	c, tc := testConn(t)
-
-	// First receive will return the correct PID
-	tc.receive = [][]Message{{
-		{
-			Header: Header{
-				Length: uint32(nlmsgAlign(nlmsgLength(0))),
-				PID:    pid,
-			},
-		},
-	}}
-
-	if _, err := c.Receive(); err != nil {
-		t.Fatalf("failed to receive messages: %v", err)
-	}
-
-	// Reset; second receive will return the wrong PID
-	tc.calls = 0
-	tc.receive = [][]Message{{
-		{
-			Header: Header{
-				Length: uint32(nlmsgAlign(nlmsgLength(0))),
-				PID:    pid * 2,
-			},
-		},
-	}}
-
-	if _, err := c.Receive(); err != nil {
-		t.Fatalf("failed to receive messages: %v", err)
-	}
-
-	// Expect the correct, first PID
-	if want, got := pid, *c.pid; want != got {
-		t.Fatalf("unexpected output PID:\n- want: %d\n-  got: %d",
-			want, got)
-	}
-}
-
-func TestConnReceive(t *testing.T) {
-	tests := []struct {
-		name    string
-		receive [][]Message
-		pid     uint32
-	}{
-		{
-			name: "first message PID OK",
-			receive: [][]Message{{
-				{
-					Header: Header{
-						Length:   uint32(nlmsgAlign(nlmsgLength(4))),
-						Sequence: 1,
-						PID:      10,
-					},
-					Data: []byte{0x00, 0x11, 0x22, 0x33},
-				},
-				{
-					Header: Header{
-						Length:   uint32(nlmsgAlign(nlmsgLength(4))),
-						Sequence: 1,
-						PID:      20,
-					},
-					Data: []byte{0x44, 0x55, 0x66, 0x77},
-				},
-			}},
-			pid: 10,
-		},
-		{
-			name: "multicast OK",
-			receive: [][]Message{
-				{
-					{
-						Header: Header{
-							Length:   uint32(nlmsgAlign(nlmsgLength(4))),
-							Sequence: 1,
-							PID:      10,
-						},
-						Data: []byte{0x00, 0x11, 0x22, 0x33},
-					},
-				},
-				{
-					{
-						Header: Header{
-							Length:   uint32(nlmsgAlign(nlmsgLength(4))),
-							Sequence: 1,
-							PID:      0,
-						},
-						Data: []byte{0x00, 0x11, 0x22, 0x33},
-					},
-				},
-			},
-			pid: 10,
-		},
-		{
-			name: "normal message OK",
-			receive: [][]Message{{
-				{
-					Header: Header{
-						Length:   uint32(nlmsgAlign(nlmsgLength(4))),
-						Sequence: 1,
-						PID:      10,
-					},
-					Data: []byte{0x00, 0x11, 0x22, 0x33},
-				},
-				{
-					Header: Header{
-						Length:   uint32(nlmsgAlign(nlmsgLength(4))),
-						Sequence: 1,
-						PID:      10,
-					},
-					Data: []byte{0x44, 0x55, 0x66, 0x77},
-				},
-			}},
-			pid: 10,
-		},
-		{
-			name: "multiple receives keep PID OK",
-			receive: [][]Message{
-				{
-					{
-						Header: Header{
-							Length:   uint32(nlmsgAlign(nlmsgLength(4))),
-							Sequence: 1,
-							PID:      10,
-						},
-						Data: []byte{0x00, 0x11, 0x22, 0x33},
-					},
-				},
-				{
-					{
-						Header: Header{
-							Length:   uint32(nlmsgAlign(nlmsgLength(4))),
-							Sequence: 1,
-							PID:      20,
-						},
-						Data: []byte{0x44, 0x55, 0x66, 0x77},
-					},
-				},
-			},
-			pid: 10,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c, tc := testConn(t)
-			tc.receive = tt.receive
-
-			for _, recv := range tt.receive {
-				msgs, err := c.Receive()
-				if err != nil {
-					t.Fatalf("failed to receive messages: %v", err)
-				}
-
-				if want, got := recv, msgs; !reflect.DeepEqual(want, got) {
-					t.Fatalf("unexpected output messages from Conn.Receive:\n- want: %#v\n-  got: %#v",
-						want, got)
-				}
-
-				if want, got := tt.pid, *c.pid; want != got {
-					t.Fatalf("unexpected output PID:\n- want: %d\n-  got: %d",
-						want, got)
-				}
-			}
-		})
-	}
-}
-
 func TestConnReceiveMultiPartOnce(t *testing.T) {
-	c, tc := testConn(t)
+	c, tc := testConn(t, 0)
 
 	tc.receive = [][]Message{
 		{
@@ -295,7 +128,7 @@ func TestConnReceiveMultiPartOnce(t *testing.T) {
 }
 
 func TestConnReceiveMultiPartRecursive(t *testing.T) {
-	c, tc := testConn(t)
+	c, tc := testConn(t, 0)
 
 	tc.receive = [][]Message{
 		{
@@ -342,7 +175,7 @@ func TestConnReceiveMultiPartRecursive(t *testing.T) {
 }
 
 func TestConnReceiveShortErrorMessage(t *testing.T) {
-	c, tc := testConn(t)
+	c, tc := testConn(t, 0)
 	tc.receive = [][]Message{{
 		{
 			Header: Header{
@@ -494,9 +327,9 @@ func TestValidate(t *testing.T) {
 	}
 }
 
-func testConn(t *testing.T) (*Conn, *testOSConn) {
+func testConn(t *testing.T, pid uint32) (*Conn, *testOSConn) {
 	c := &testOSConn{}
-	return newConn(c), c
+	return newConn(c, pid), c
 }
 
 type testOSConn struct {


### PR DESCRIPTION
Simplifies things, and removes some complicated logic and tests.  Double win.