### PR TITLE
Attribute helpers for nesting, endianness and a mask over .Type

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -25,27 +25,27 @@ type Attribute struct {
 	Data []byte
 }
 
-// Interprets the Type field of the Attribute to determine whether it's
+// IsNested interprets the Type field of the Attribute to determine whether it's
 // a nested attribute or not. This facilitates recursive parsing of the attribute.
 // This is the leftmost bit in Type. Mutually exclusive with IsNetByteOrder().
 func (a Attribute) IsNested() bool {
 	return (a.Type & unix.NLA_F_NESTED) > 0
 }
 
-// Interprets the Type field of the Attribute to determine whether the attribute
+// IsNetByteOrder interprets the Type field of the Attribute to determine whether the attribute
 // is big endian (net byte order) or not.
 // This is the second bit from the left in Type. Mutually exclusive with IsNested().
 func (a Attribute) IsNetByteOrder() bool {
 	return (a.Type & unix.NLA_F_NET_BYTEORDER) > 0
 }
 
-const NLA_TYPE_MASK = ^uint16(unix.NLA_F_NESTED | unix.NLA_F_NET_BYTEORDER)
+var nlaTypeMask = ^uint16(unix.NLA_F_NESTED | unix.NLA_F_NET_BYTEORDER)
 
-// Mask the Attribute's Type with the bits that are NOT
+// GetType masks the Attribute's Type with the bits that are NOT
 // reserved for NLA_F_NESTED and NLA_F_NET_BYTEORDER.
 // Only the 14 rightmost bits will be used.
 func (a Attribute) GetType() uint16 {
-	return a.Type & NLA_TYPE_MASK
+	return a.Type & nlaTypeMask
 }
 
 // MarshalBinary marshals an Attribute into a byte slice.

--- a/attribute.go
+++ b/attribute.go
@@ -26,10 +26,10 @@ type Attribute struct {
 	// An arbitrary payload which is specified by Type.
 	Data []byte
 
-	// Whether the attribute contains nested attributes.
+	// Whether the attribute's data contains nested attributes.
 	Nested bool
 
-	// Whether the attribute is in network (true) or native (false) byte order.
+	// Whether the attribute's data is in network (true) or native (false) byte order.
 	NetByteOrder bool
 }
 
@@ -37,7 +37,7 @@ type Attribute struct {
 const nlaNested uint16 = 0x8000
 // #define NLA_F_NET_BYTE_ORDER
 const nlaNetByteOrder uint16 = 0x4000
-// Masks all bits except for Nested and NetByteOrder
+// Masks all bits except for Nested and NetByteOrder.
 const nlaTypeMask = ^(nlaNested | nlaNetByteOrder)
 
 // MarshalBinary marshals an Attribute into a byte slice.

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -367,3 +367,70 @@ func TestUnmarshalAttributes(t *testing.T) {
 		})
 	}
 }
+
+func TestAttribute_GetType(t *testing.T) {
+	// Small test bed of values that map to
+	// counterparts with the two leftmost bits zeroed out.
+	types := map[uint16]uint16{
+		0xAAAA: 0x2AAA,
+		0xFFFF: 0x3FFF,
+		0x2AAA: 0x2AAA,
+		0x0FFF: 0x0FFF,
+		0x0: 0x0,
+	}
+
+	for input, want := range types {
+		test := Attribute{
+			Type: input,
+		}
+
+		if got := test.GetType(); got != want {
+			t.Fatalf("unexpected result:\n- want: %.16b\n- got: %.16b",
+				want, got)
+		}
+	}
+}
+
+func TestAttribute_IsNested(t *testing.T) {
+	// These values map to 'true' when the leftmost bit is on
+	types := map[uint16]bool{
+		0xBFFF: true,
+		0xFFFF: true,
+		0x7FFF: false,
+		0x0123: false,
+		0x0: false,
+	}
+
+	for input, want := range types {
+		test := Attribute{
+			Type: input,
+		}
+
+		if got := test.IsNested(); got != want {
+			t.Fatalf("expected nested bit to be set to %v in input %.16b (got %v)",
+				want, input, got)
+		}
+	}
+}
+
+func TestAttribute_IsNetByteOrder(t *testing.T) {
+	// These values map to 'true' when the second-leftmost bit is on
+	types := map[uint16]bool{
+		0xBFFF: false,
+		0xFFFF: true,
+		0x7FFF: true,
+		0x0123: false,
+		0x0: false,
+	}
+
+	for input, want := range types {
+		test := Attribute{
+			Type: input,
+		}
+
+		if got := test.IsNetByteOrder(); got != want {
+			t.Fatalf("expected big-endian bit to be set to %v in input %.16b (got %v)",
+				want, input, got)
+		}
+	}
+}

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -186,6 +186,65 @@ func TestMarshalAttributes(t *testing.T) {
 				0x33, 0x33, 0x33, 0x33,
 			},
 		},
+		{
+			name: "nested and endianness bits",
+			attrs: []Attribute{
+				{
+					Length: 4,
+					Type: 0,
+					Nested: true,
+					NetByteOrder: true,
+					Data: make([]byte, 0),
+				},
+			},
+			err: errInvalidAttributeFlags,
+		},
+		{
+			name: "nested bit, type 1, length 0",
+			attrs: []Attribute{
+				{
+					Length: 4,
+					Type: 1,
+					Nested: true,
+					Data: make([]byte, 0),
+				},
+			},
+			b: []byte{
+				0x04, 0x00,
+				0x01, 0x80, // Nested bit
+			},
+		},
+		{
+			name: "endianness bit, type 1, length 0",
+			attrs: []Attribute{
+				{
+					Length: 4,
+					Type: 1,
+					NetByteOrder: true,
+					Data: make([]byte, 0),
+				},
+			},
+			b: []byte{
+				0x04, 0x00,
+				0x01, 0x40, // NetByteOrder bit
+			},
+		},
+		{
+			name: "max type space, length 0",
+			attrs: []Attribute{
+				{
+					Length: 4,
+					Type: 16383,
+					Nested: false,
+					NetByteOrder: false,
+					Data: make([]byte, 0),
+				},
+			},
+			b: []byte{
+				0x04, 0x00,
+				0xFF, 0x3F, // 14 lowest type bits up
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -347,6 +406,14 @@ func TestUnmarshalAttributes(t *testing.T) {
 			},
 		},
 		{
+			name: "nested and endianness bits",
+			b: []byte{
+				0x04, 0x00,
+				0x00, 0xC0, // both bits set
+			},
+			err: errInvalidAttributeFlags,
+		},
+		{
 			name: "nested bit, type 1, length 0",
 			b: []byte{
 				0x04, 0x00,
@@ -371,22 +438,6 @@ func TestUnmarshalAttributes(t *testing.T) {
 				{
 					Length: 4,
 					Type: 1,
-					NetByteOrder: true,
-					Data: make([]byte, 0),
-				},
-			},
-		},
-		{
-			name: "type overflow, length 0",
-			b: []byte{
-				0x04, 0x00,
-				0xFF, 0xFF, // All Type bits up, including Nested and NetByteOrder
-			},
-			attrs: []Attribute{
-				{
-					Length: 4,
-					Type: 16383,
-					Nested: true,
 					NetByteOrder: true,
 					Data: make([]byte, 0),
 				},


### PR DESCRIPTION
Hi, I've added three helpers to `Attribute` including some tests. These are all exported to allow eg. NetFilter to make use of them, which should be their main purpose IMO. They're not implemented as struct members to avoid having to change (and bloat) the struct.

- IsNested() - masks leftmost bit
- IsNetByteOrder() - masks second leftmost bit
- GetType() - masks all other bits from the Type

I have benched using pointer receivers for these, but there was no perceivable performance difference. Let me know what you think!

T