### PR TITLE
Use nlaHeaderLen instead of magic nr. 4

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -63,7 +63,7 @@ func (a Attribute) MarshalBinary() ([]byte, error) {
 		nlenc.PutUint16(b[2:4], a.Type)
 	}
 
-	copy(b[4:], a.Data)
+	copy(b[nlaHeaderLen:], a.Data)
 
 	return b, nil
 }
@@ -96,12 +96,12 @@ func (a *Attribute) UnmarshalBinary(b []byte) error {
 	case a.Length == 0:
 		a.Data = make([]byte, 0)
 	// Not enough length for any data
-	case a.Length < 4:
+	case int(a.Length) < nlaHeaderLen:
 		return errInvalidAttribute
 	// Data present
-	case a.Length >= 4:
-		a.Data = make([]byte, len(b[4:a.Length]))
-		copy(a.Data, b[4:a.Length])
+	case int(a.Length) >= nlaHeaderLen:
+		a.Data = make([]byte, len(b[nlaHeaderLen:a.Length]))
+		copy(a.Data, b[nlaHeaderLen:a.Length])
 	}
 
 	return nil


### PR DESCRIPTION
Small change as discussed. I've left occurrences like `b[2:4]` untouched, since it's clear we're dealing with a slice range.

Not sure if the changes to the `case`s are for the better.