### PR TITLE
docs: move comments about members of Header struct

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -106,15 +106,6 @@ func (c *Conn) Execute(m Message) ([]Message, error) {
 // Sequence, and PID fields should be set to 0, so they can be populated
 // automatically before the Message is sent.  On success, Send returns a copy
 // of the Message with all parameters populated, for later validation.
-//
-// If m.Header.Length is 0, it will be automatically populated using the
-// correct length for the Message, including its payload.
-//
-// If m.Header.Sequence is 0, it will be automatically populated using the
-// next sequence number for this connection.
-//
-// If m.Header.PID is 0, it will be automatically populated using a PID
-// assigned by netlink.
 func (c *Conn) Send(m Message) (Message, error) {
 	ml := nlmsgLength(len(m.Data))
 

--- a/message.go
+++ b/message.go
@@ -140,6 +140,8 @@ func (t HeaderType) String() string {
 // Message to indicate metadata regarding a Message.
 type Header struct {
 	// Length of a Message, including this Header.
+	// If Length is 0, it will be automatically populated using the
+	// correct length for the Message, including its payload.
 	Length uint32
 
 	// Contents of a Message.
@@ -149,9 +151,13 @@ type Header struct {
 	Flags HeaderFlags
 
 	// The sequence number of a Message.
+	// If Sequence is 0, it will be automatically populated using the
+	// next sequence number for this connection.
 	Sequence uint32
 
 	// The process ID of the sending process.
+	// If PID is 0, it will be automatically populated using a PID
+	// assigned by netlink.
 	PID uint32
 }
 


### PR DESCRIPTION
This patch moves comments about if some values are `0` on Send()
function to members of Header struct.  These comments should be
 checked on Header struct in the GoDocs.