### PR TITLE
update TestLinuxConnIntegration for recent kernel versions

### DIFF
--- a/conn_linux_test.go
+++ b/conn_linux_test.go
@@ -344,8 +344,9 @@ func TestLinuxConnIntegration(t *testing.T) {
 	if want, got := HeaderTypeError, m.Header.Type; want != got {
 		t.Fatalf("unexpected header type:\n- want: %v\n-  got: %v", want, got)
 	}
-	if want, got := 0, int(m.Header.Flags); want != got {
-		t.Fatalf("unexpected header flags:\n- want: %v\n-  got: %v", want, got)
+	// Recent kernel versions (> 4.14) return a 256 here instead of a 0
+	if want, wantAlt, got := 0, 256, int(m.Header.Flags); want != got && wantAlt != got {
+		t.Fatalf("unexpected header flags:\n- want: %v or %v\n-  got: %v", want, wantAlt, got)
 	}
 
 	// Sequence number not checked because we assign one at random when


### PR DESCRIPTION
Recent kernel versions return the NLM_F_ROOT (0x100) header flag.

I'm not sure if this is the right fix for this, but this test currently fails on recent distributions (Fedora 27 and Ubuntu 18.04) because the header section of the message contains the NLM_F_ROOT flag (256/0x100).