### PR TITLE
netlink: remove Nested and NetByteOrder from Attribute

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -9,9 +9,6 @@ import (
 var (
 	// errInvalidAttribute specifies if an Attribute's length is incorrect.
 	errInvalidAttribute = errors.New("invalid attribute; length too short or too large")
-	// errInvalidAttributeFlags specifies if an Attribute's flag configuration is invalid.
-	// From a comment in Linux/include/uapi/linux/netlink.h, Nested and NetByteOrder are mutually exclusive.
-	errInvalidAttributeFlags = errors.New("invalid attribute; type cannot have both nested and net byte order flags")
 )
 
 // An Attribute is a netlink attribute.  Attributes are packed and unpacked
@@ -25,25 +22,7 @@ type Attribute struct {
 
 	// An arbitrary payload which is specified by Type.
 	Data []byte
-
-	// Whether the attribute's data contains nested attributes.  Note that not
-	// all netlink families set this value.  The programmer should consult
-	// documentation and inspect an attribute's data to determine if nested
-	// attributes are present.
-	Nested bool
-
-	// Whether the attribute's data is in network (true) or native (false) byte order.
-	NetByteOrder bool
 }
-
-// #define NLA_F_NESTED
-const nlaNested uint16 = 0x8000
-
-// #define NLA_F_NET_BYTE_ORDER
-const nlaNetByteOrder uint16 = 0x4000
-
-// Masks all bits except for Nested and NetByteOrder.
-const nlaTypeMask = ^(nlaNested | nlaNetByteOrder)
 
 // MarshalBinary marshals an Attribute into a byte slice.
 func (a Attribute) MarshalBinary() ([]byte, error) {
@@ -51,22 +30,10 @@ func (a Attribute) MarshalBinary() ([]byte, error) {
 		return nil, errInvalidAttribute
 	}
 
-	if a.NetByteOrder && a.Nested {
-		return nil, errInvalidAttributeFlags
-	}
-
 	b := make([]byte, nlaAlign(int(a.Length)))
 
 	nlenc.PutUint16(b[0:2], a.Length)
-
-	switch {
-	case a.Nested:
-		nlenc.PutUint16(b[2:4], a.Type|nlaNested)
-	case a.NetByteOrder:
-		nlenc.PutUint16(b[2:4], a.Type|nlaNetByteOrder)
-	default:
-		nlenc.PutUint16(b[2:4], a.Type)
-	}
+	nlenc.PutUint16(b[2:4], a.Type)
 
 	copy(b[nlaHeaderLen:], a.Data)
 
@@ -80,20 +47,10 @@ func (a *Attribute) UnmarshalBinary(b []byte) error {
 	}
 
 	a.Length = nlenc.Uint16(b[0:2])
-
-	// Only hold the rightmost 14 bits in Type
-	a.Type = nlenc.Uint16(b[2:4]) & nlaTypeMask
-
-	// Boolean flags extracted from the two leftmost bits of Type
-	a.Nested = (nlenc.Uint16(b[2:4]) & nlaNested) > 0
-	a.NetByteOrder = (nlenc.Uint16(b[2:4]) & nlaNetByteOrder) > 0
+	a.Type = nlenc.Uint16(b[2:4])
 
 	if nlaAlign(int(a.Length)) > len(b) {
 		return errInvalidAttribute
-	}
-
-	if a.NetByteOrder && a.Nested {
-		return errInvalidAttributeFlags
 	}
 
 	switch {

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -189,62 +189,17 @@ func TestMarshalAttributes(t *testing.T) {
 			},
 		},
 		{
-			name: "nested and endianness bits",
-			attrs: []Attribute{
-				{
-					Length:       4,
-					Type:         0,
-					Nested:       true,
-					NetByteOrder: true,
-					Data:         make([]byte, 0),
-				},
-			},
-			err: errInvalidAttributeFlags,
-		},
-		{
-			name: "nested bit, type 1, length 0",
+			name: "max type space, length 0",
 			attrs: []Attribute{
 				{
 					Length: 4,
-					Type:   1,
-					Nested: true,
+					Type:   0xffff,
 					Data:   make([]byte, 0),
 				},
 			},
 			b: []byte{
 				0x04, 0x00,
-				0x01, 0x80, // Nested bit
-			},
-		},
-		{
-			name: "endianness bit, type 1, length 0",
-			attrs: []Attribute{
-				{
-					Length:       4,
-					Type:         1,
-					NetByteOrder: true,
-					Data:         make([]byte, 0),
-				},
-			},
-			b: []byte{
-				0x04, 0x00,
-				0x01, 0x40, // NetByteOrder bit
-			},
-		},
-		{
-			name: "max type space, length 0",
-			attrs: []Attribute{
-				{
-					Length:       4,
-					Type:         16383,
-					Nested:       false,
-					NetByteOrder: false,
-					Data:         make([]byte, 0),
-				},
-			},
-			b: []byte{
-				0x04, 0x00,
-				0xFF, 0x3F, // 14 lowest type bits up
+				0xff, 0xff,
 			},
 		},
 	}
@@ -410,56 +365,16 @@ func TestUnmarshalAttributes(t *testing.T) {
 			},
 		},
 		{
-			name: "nested and endianness bits",
+			name: "max type space, length 0",
 			b: []byte{
 				0x04, 0x00,
-				0x00, 0xC0, // both bits set
-			},
-			err: errInvalidAttributeFlags,
-		},
-		{
-			name: "nested bit, type 1, length 0",
-			b: []byte{
-				0x04, 0x00,
-				0x01, 0x80, // Nested bit
+				0xff, 0xff,
 			},
 			attrs: []Attribute{
 				{
 					Length: 4,
-					Type:   1,
-					Nested: true,
+					Type:   0xffff,
 					Data:   make([]byte, 0),
-				},
-			},
-		},
-		{
-			name: "endianness bit, type 1, length 0",
-			b: []byte{
-				0x04, 0x00,
-				0x01, 0x40, // NetByteOrder bit
-			},
-			attrs: []Attribute{
-				{
-					Length:       4,
-					Type:         1,
-					NetByteOrder: true,
-					Data:         make([]byte, 0),
-				},
-			},
-		},
-		{
-			name: "max type space, length 0",
-			b: []byte{
-				0x04, 0x00,
-				0xFF, 0x3F, // 14 lowest type bits up
-			},
-			attrs: []Attribute{
-				{
-					Length:       4,
-					Type:         16383,
-					Nested:       false,
-					NetByteOrder: false,
-					Data:         make([]byte, 0),
 				},
 			},
 		},


### PR DESCRIPTION
I haven't seen a netlink message yet that actually uses these, and since nested attributes in particular appear all the time without this flag being set, it doesn't seem to provide any added value.

For the time being, let's remove these.