### PR TITLE
fixes building on non-linux systems

### DIFF
--- a/conn_others.go
+++ b/conn_others.go
@@ -31,6 +31,11 @@ func (c *conn) Send(m Message) error {
 	return errUnimplemented
 }
 
+// SendMessages always returns an error.
+func (c *conn) SendMessages(m []Message) error {
+	return errUnimplemented
+}
+
 // Receive always returns an error.
 func (c *conn) Receive() ([]Message, error) {
 	return nil, errUnimplemented

--- a/conn_others_test.go
+++ b/conn_others_test.go
@@ -25,6 +25,11 @@ func TestOthersConnUnimplemented(t *testing.T) {
 			want, got)
 	}
 
+	if got := c.SendMessages(nil); want != got {
+		t.Fatalf("unexpected error during c.SendMessages:\n- want: %v\n-  got: %v",
+			want, got)
+	}
+
 	if _, got := c.Receive(); want != got {
 		t.Fatalf("unexpected error during c.Receive:\n- want: %v\n-  got: %v",
 			want, got)


### PR DESCRIPTION
SendMessages() added to non-linux implementation of conn to match Socket interface. Some packages depending on netlink fail to build due to this since SendMessages method was merged in May 2018