### PR TITLE
Add DetachBPF

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -314,6 +314,7 @@ func (c *Conn) LeaveGroup(group uint32) error {
 type bpfSetter interface {
 	Socket
 	bpf.Setter
+	DetachBFP() error
 }
 
 // SetBPF attaches an assembled BPF program to a Conn.
@@ -324,6 +325,16 @@ func (c *Conn) SetBPF(filter []bpf.RawInstruction) error {
 	}
 
 	return bc.SetBPF(filter)
+}
+
+// DetachBPF removes a BPF filter from a Conn.
+func (c *Conn) DetachBPF() error {
+	s, ok := c.sock.(bpfSetter)
+	if !ok {
+		return errBPFFiltersNotSupported
+	}
+
+	return s.DetachBFP()
 }
 
 // A ConnOption is a boolean option that may be set for a Conn.

--- a/conn_linux.go
+++ b/conn_linux.go
@@ -226,6 +226,16 @@ func (c *conn) SetBPF(filter []bpf.RawInstruction) error {
 	)
 }
 
+// DetachBFP removes a BPF filter from a conn.
+func (c *conn) DetachBPF() error {
+	var dummy int
+	return c.s.SetSockopt(
+		unix.SOL_SOCKET,
+		unix.SO_DETACH_FILTER,
+		unsafe.Pointer(&dummy),
+		uint32(unsafe.Sizeof(dummy)))
+}
+
 // SetOption enables or disables a netlink socket option for the Conn.
 func (c *conn) SetOption(option ConnOption, enable bool) error {
 	o, ok := linuxOption(option)

--- a/conn_others.go
+++ b/conn_others.go
@@ -61,6 +61,11 @@ func (c *conn) SetBPF(filter []bpf.RawInstruction) error {
 	return errUnimplemented
 }
 
+// DetachBPF always returns an error.
+func (c *conn) DetachBPF() error {
+	return errUnimplemented
+}
+
 // SetOption always returns an error.
 func (c *conn) SetOption(option ConnOption, enable bool) error {
 	return errUnimplemented


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

This PR adds the ability, to remove a previously attached BPF from a connection.