### PR TITLE
netlink: add benchmarks for attribute handling

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,79 @@
+package netlink_test
+
+import (
+	"testing"
+
+	"github.com/mdlayher/netlink"
+)
+
+var attrBench = []struct {
+	name  string
+	attrs []netlink.Attribute
+}{
+	{
+		name: "0",
+	},
+	{
+		name:  "1",
+		attrs: makeAttributes(1),
+	},
+	{
+		name:  "8",
+		attrs: makeAttributes(8),
+	},
+	{
+		name:  "64",
+		attrs: makeAttributes(64),
+	},
+	{
+		name:  "512",
+		attrs: makeAttributes(512),
+	},
+}
+
+func BenchmarkMarshalAttributes(b *testing.B) {
+	for _, tt := range attrBench {
+		b.Run(tt.name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				if _, err := netlink.MarshalAttributes(tt.attrs); err != nil {
+					b.Fatalf("failed to marshal: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkUnmarshalAttributes(b *testing.B) {
+	for _, tt := range attrBench {
+		b.Run(tt.name, func(b *testing.B) {
+			buf, err := netlink.MarshalAttributes(tt.attrs)
+			if err != nil {
+				b.Fatalf("failed to marshal: %v", err)
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				if _, err := netlink.UnmarshalAttributes(buf); err != nil {
+					b.Fatalf("failed to unmarshal: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func makeAttributes(n int) []netlink.Attribute {
+	attrs := make([]netlink.Attribute, 0, n)
+	for i := 0; i < n; i++ {
+		attrs = append(attrs, netlink.Attribute{
+			Type: uint16(i),
+			Data: make([]byte, n),
+		})
+	}
+
+	return attrs
+}


### PR DESCRIPTION
Before we look at optimizing anything, here's a base line.

```
✔ ~/src/github.com/mdlayher/netlink [mdl-attr-bench L|✚ 1…4] 
16:58 $ for i in `seq 1 5`; do go test -bench=. -run=NONE . >> before.bench; done
✔ ~/src/github.com/mdlayher/netlink [mdl-attr-bench L|✚ 1…5] 
17:00 $ cat before.bench 
goos: linux
goarch: amd64
pkg: github.com/mdlayher/netlink
BenchmarkMarshalAttributes/0-8          200000000                8.36 ns/op            0 B/op          0 allocs/op
BenchmarkMarshalAttributes/1-8          20000000                64.9 ns/op            24 B/op          3 allocs/op
BenchmarkMarshalAttributes/8-8           3000000               410 ns/op             320 B/op         10 allocs/op
BenchmarkMarshalAttributes/64-8           200000              6859 ns/op           14592 B/op         66 allocs/op
BenchmarkMarshalAttributes/512-8           10000            180613 ns/op          884736 B/op        514 allocs/op
BenchmarkUnmarshalAttributes/0-8        500000000                3.43 ns/op            0 B/op          0 allocs/op
BenchmarkUnmarshalAttributes/1-8        20000000                70.2 ns/op            33 B/op          2 allocs/op
BenchmarkUnmarshalAttributes/8-8         2000000               652 ns/op             544 B/op         12 allocs/op
BenchmarkUnmarshalAttributes/64-8                 300000              5441 ns/op            8160 B/op         71 allocs/op
BenchmarkUnmarshalAttributes/512-8                 20000             99895 ns/op          294880 B/op        522 allocs/op
PASS
ok      github.com/mdlayher/netlink     18.996s
goos: linux
goarch: amd64
pkg: github.com/mdlayher/netlink
BenchmarkMarshalAttributes/0-8          200000000                8.34 ns/op            0 B/op          0 allocs/op
BenchmarkMarshalAttributes/1-8          20000000                64.0 ns/op            24 B/op          3 allocs/op
BenchmarkMarshalAttributes/8-8           3000000               427 ns/op             320 B/op         10 allocs/op
BenchmarkMarshalAttributes/64-8           200000              5710 ns/op           14592 B/op         66 allocs/op
BenchmarkMarshalAttributes/512-8           10000            174468 ns/op          884736 B/op        514 allocs/op
BenchmarkUnmarshalAttributes/0-8        500000000                3.43 ns/op            0 B/op          0 allocs/op
BenchmarkUnmarshalAttributes/1-8        20000000                70.3 ns/op            33 B/op          2 allocs/op
BenchmarkUnmarshalAttributes/8-8         2000000               681 ns/op             544 B/op         12 allocs/op
BenchmarkUnmarshalAttributes/64-8                 300000              5648 ns/op            8160 B/op         71 allocs/op
BenchmarkUnmarshalAttributes/512-8                 20000             98597 ns/op          294880 B/op        522 allocs/op
PASS
ok      github.com/mdlayher/netlink     18.752s
goos: linux
goarch: amd64
pkg: github.com/mdlayher/netlink
BenchmarkMarshalAttributes/0-8          200000000                8.34 ns/op            0 B/op          0 allocs/op
BenchmarkMarshalAttributes/1-8          20000000                63.7 ns/op            24 B/op          3 allocs/op
BenchmarkMarshalAttributes/8-8           3000000               409 ns/op             320 B/op         10 allocs/op
BenchmarkMarshalAttributes/64-8           200000              6960 ns/op           14592 B/op         66 allocs/op
BenchmarkMarshalAttributes/512-8           10000            182423 ns/op          884736 B/op        514 allocs/op
BenchmarkUnmarshalAttributes/0-8        500000000                3.42 ns/op            0 B/op          0 allocs/op
BenchmarkUnmarshalAttributes/1-8        20000000                70.5 ns/op            33 B/op          2 allocs/op
BenchmarkUnmarshalAttributes/8-8         2000000               648 ns/op             544 B/op         12 allocs/op
BenchmarkUnmarshalAttributes/64-8                 300000              5954 ns/op            8160 B/op         71 allocs/op
BenchmarkUnmarshalAttributes/512-8                 20000            103445 ns/op          294880 B/op        522 allocs/op
PASS
ok      github.com/mdlayher/netlink     19.242s
goos: linux
goarch: amd64
pkg: github.com/mdlayher/netlink
BenchmarkMarshalAttributes/0-8          200000000                8.36 ns/op            0 B/op          0 allocs/op
BenchmarkMarshalAttributes/1-8          20000000                63.8 ns/op            24 B/op          3 allocs/op
BenchmarkMarshalAttributes/8-8           3000000               408 ns/op             320 B/op         10 allocs/op
BenchmarkMarshalAttributes/64-8           300000              6874 ns/op           14592 B/op         66 allocs/op
BenchmarkMarshalAttributes/512-8           10000            182739 ns/op          884736 B/op        514 allocs/op
BenchmarkUnmarshalAttributes/0-8        500000000                3.43 ns/op            0 B/op          0 allocs/op
BenchmarkUnmarshalAttributes/1-8        20000000                70.7 ns/op            33 B/op          2 allocs/op
BenchmarkUnmarshalAttributes/8-8         2000000               674 ns/op             544 B/op         12 allocs/op
BenchmarkUnmarshalAttributes/64-8                 300000              5811 ns/op            8160 B/op         71 allocs/op
BenchmarkUnmarshalAttributes/512-8                 20000             99251 ns/op          294880 B/op        522 allocs/op
PASS
ok      github.com/mdlayher/netlink     19.787s
goos: linux
goarch: amd64
pkg: github.com/mdlayher/netlink
BenchmarkMarshalAttributes/0-8          200000000                8.33 ns/op            0 B/op          0 allocs/op
BenchmarkMarshalAttributes/1-8          20000000                63.5 ns/op            24 B/op          3 allocs/op
BenchmarkMarshalAttributes/8-8           3000000               400 ns/op             320 B/op         10 allocs/op
BenchmarkMarshalAttributes/64-8           200000              6676 ns/op           14592 B/op         66 allocs/op
BenchmarkMarshalAttributes/512-8           10000            170220 ns/op          884736 B/op        514 allocs/op
BenchmarkUnmarshalAttributes/0-8        500000000                3.42 ns/op            0 B/op          0 allocs/op
BenchmarkUnmarshalAttributes/1-8        20000000                68.6 ns/op            33 B/op          2 allocs/op
BenchmarkUnmarshalAttributes/8-8         2000000               643 ns/op             544 B/op         12 allocs/op
BenchmarkUnmarshalAttributes/64-8                 300000              5907 ns/op            8160 B/op         71 allocs/op
BenchmarkUnmarshalAttributes/512-8                 20000             96807 ns/op          294880 B/op        522 allocs/op
PASS
ok      github.com/mdlayher/netlink     18.896s
```