### PR TITLE
feat: add Bytes func to AttributeDecoder

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -225,6 +225,14 @@ func (ad *AttributeDecoder) Err() error {
 	return ad.err
 }
 
+// Bytes returns the raw bytes of the current Attribute's data.
+func (ad *AttributeDecoder) Bytes() []byte {
+	src := ad.data()
+	dest := make([]byte, len(src))
+	copy(dest, src)
+	return dest
+}
+
 // String returns the string representation of the current Attribute's data.
 func (ad *AttributeDecoder) String() string {
 	if ad.err != nil {

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -525,6 +525,32 @@ func TestAttributeDecoderOK(t *testing.T) {
 			fn:    adEndianTest(binary.BigEndian),
 		},
 		{
+			name: "bytes",
+			attrs: []Attribute{{
+				Type: 1,
+				Data: []byte{0xde, 0xad},
+			}},
+			fn: func(ad *AttributeDecoder) {
+				var b []byte
+				switch t := ad.Type(); t {
+				case 1:
+					b = ad.Bytes()
+				default:
+					panicf("unhandled attribute type: %d", t)
+				}
+
+				if diff := cmp.Diff([]byte{0xde, 0xad}, b); diff != "" {
+					panicf("unexpected attribute value (-want +got):\n%s", diff)
+				}
+
+				b[0] = 0xff
+
+				if diff := cmp.Diff(b, ad.Bytes()); diff == "" {
+					panic("expected attribute value to be copied and different")
+				}
+			},
+		},
+		{
 			name: "string",
 			attrs: []Attribute{{
 				Type: 1,


### PR DESCRIPTION
For symmetry with AttributeEncoder, adds a Bytes function to
AttriuteDecoder that copies the bytes to a new slice to avoid retaining
the original.