### PR TITLE
Align nl message length

### DIFF
--- a/conn_linux.go
+++ b/conn_linux.go
@@ -129,12 +129,6 @@ func (c *conn) Send(m Message) error {
 	return c.s.Sendmsg(b, nil, addr, 0)
 }
 
-// Round the length of a netlink message up to align it properly.
-// copy from syscall/netlink_linux.go:nlmAlignOf()
-func nlmAlignOf(msglen int) int {
-	return (msglen + syscall.NLMSG_ALIGNTO - 1) & ^(syscall.NLMSG_ALIGNTO - 1)
-}
-
 // Receive receives one or more Messages from netlink.
 func (c *conn) Receive() ([]Message, error) {
 	b := make([]byte, os.Getpagesize())
@@ -171,7 +165,7 @@ func (c *conn) Receive() ([]Message, error) {
 		return nil, errInvalidFamily
 	}
 
-	n = nlmAlignOf(n)
+	n = nlmsgAlign(n)
 
 	raw, err := syscall.ParseNetlinkMessage(b[:n])
 	if err != nil {

--- a/conn_linux_test.go
+++ b/conn_linux_test.go
@@ -291,11 +291,6 @@ func TestLinuxConnReceiveMultipleMessagesLastUnaligned(t *testing.T) {
 
 	msgs, err := c.Receive()
 	if err != nil {
-		// TODO(mdlayher): remove once CL 35531 is merged and released.
-		if err == syscall.EINVAL {
-			t.Skip("skipping, see: https://golang.org/cl/35531/")
-		}
-
 		t.Fatalf("failed to receive messages: %v", err)
 	}
 


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

While working on florianl/go-nfqueue, I've noticed netlink messages from the kernel without correct alignment. Besides the alignment, these messages are fine and can be parsed without problem.

I've traced down this issue to `func (c *conn) Receive() ([]Message, error)` in `conn_linux.go`, where `syscall.ParseNetlinkMessage()` failed with `EINVAL`.
E.g. `n` for `Recvmsg(b, nil, unix.MSG_PEEK)` is 171, `n` for `Recvmsg(b, nil, 0)` is also 171 and `syscall.ParseNetlinkMessage(b[:n])` failed because `nlmAlignOf()` in `syscall/netlink_linux.go` returns 172.