### PR TITLE
netlink: enable usage of the network poller

### DIFF
--- a/conn_linux.go
+++ b/conn_linux.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"sync"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"golang.org/x/net/bpf"
@@ -21,6 +22,8 @@ var (
 
 var _ Socket = &conn{}
 
+var _ deadlineSetter = &conn{}
+
 // A conn is the Linux implementation of a netlink sockets connection.
 type conn struct {
 	s  socket
@@ -32,9 +35,13 @@ type socket interface {
 	Bind(sa unix.Sockaddr) error
 	Close() error
 	FD() int
+	File() *os.File
 	Getsockname() (unix.Sockaddr, error)
 	Recvmsg(p, oob []byte, flags int) (n int, oobn int, recvflags int, from unix.Sockaddr, err error)
 	Sendmsg(p, oob []byte, to unix.Sockaddr, flags int) error
+	SetDeadline(t time.Time) error
+	SetReadDeadline(t time.Time) error
+	SetWriteDeadline(t time.Time) error
 	SetSockopt(level, name int, v unsafe.Pointer, l uint32) error
 }
 
@@ -195,6 +202,11 @@ func (c *conn) FD() int {
 	return c.s.FD()
 }
 
+// File retrieves the *os.File associated with the Conn.
+func (c *conn) File() *os.File {
+	return c.s.File()
+}
+
 // JoinGroup joins a multicast group by ID.
 func (c *conn) JoinGroup(group uint32) error {
 	return c.s.SetSockopt(
@@ -264,6 +276,18 @@ func (c *conn) SetOption(option ConnOption, enable bool) error {
 	)
 }
 
+func (c *conn) SetDeadline(t time.Time) error {
+	return c.s.SetDeadline(t)
+}
+
+func (c *conn) SetReadDeadline(t time.Time) error {
+	return c.s.SetReadDeadline(t)
+}
+
+func (c *conn) SetWriteDeadline(t time.Time) error {
+	return c.SetWriteDeadline(t)
+}
+
 // SetReadBuffer sets the size of the operating system's receive buffer
 // associated with the Conn.
 func (c *conn) SetReadBuffer(bytes int) error {
@@ -325,120 +349,85 @@ var _ socket = &sysSocket{}
 
 // A sysSocket is a socket which uses system calls for socket operations.
 type sysSocket struct {
-	fd int
-
-	wg    *sync.WaitGroup
-	funcC chan<- func()
-
-	mu sync.RWMutex
-
-	done  bool
-	doneC chan<- bool
+	mu     sync.RWMutex
+	fd     *os.File
+	closed bool
+	g      *lockedNetNSGoroutine
 }
 
 // newSysSocket creates a sysSocket that optionally locks its internal goroutine
 // to a single thread.
 func newSysSocket(config *Config) (*sysSocket, error) {
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	// This system call loop strategy was inspired by:
-	// https://github.com/golang/go/wiki/LockOSThread.  Thanks to squeed on
-	// Gophers Slack for providing this useful link.
-
-	funcC := make(chan func())
-	doneC := make(chan bool)
-	errC := make(chan error)
-
-	go func() {
-		// It is important to lock this goroutine to its OS thread for the duration
-		// of the netlink socket being used, or else the kernel may end up routing
-		// messages to the wrong places.
-		// See: http://lists.infradead.org/pipermail/libnl/2017-February/002293.html.
-		//
-		// The intent is to never unlock the OS thread, so that the thread
-		// will terminate when the goroutine exits starting in Go 1.10:
-		// https://go-review.googlesource.com/c/go/+/46038.
-		//
-		// However, due to recent instability and a potential bad interaction
-		// with the Go runtime for threads which are not unlocked, we have
-		// elected to temporarily unlock the thread when the goroutine terminates:
-		// https://github.com/golang/go/issues/25128#issuecomment-410764489.
-
-		runtime.LockOSThread()
-		defer runtime.UnlockOSThread()
-		defer wg.Done()
-
-		// The user requested the Conn to operate in a non-default network namespace.
-		if config.NetNS != 0 {
-
-			// Get the current namespace of the thread the goroutine is locked to.
-			origNetNS, err := getThreadNetNS()
-			if err != nil {
-				errC <- err
-				return
-			}
-
-			// Set the network namespace of the current thread using
-			// the file descriptor provided by the user.
-			err = setThreadNetNS(config.NetNS)
-			if err != nil {
-				errC <- err
-				return
-			}
-
-			// Once the thread's namespace has been successfully manipulated,
-			// make sure we change it back when the goroutine returns.
-			defer setThreadNetNS(origNetNS)
-		}
-
-		// Signal to caller that initialization was successful.
-		errC <- nil
-
-		for {
-			select {
-			case <-doneC:
-				return
-			case f := <-funcC:
-				f()
-			}
-		}
-	}()
-
-	// Wait for the goroutine to return err or nil.
-	if err := <-errC; err != nil {
+	g, err := newLockedNetNSGoroutine(config.NetNS)
+	if err != nil {
 		return nil, err
 	}
-
 	return &sysSocket{
-		wg:    &wg,
-		funcC: funcC,
-		doneC: doneC,
+		g: g,
 	}, nil
 }
 
 // do runs f in a worker goroutine which can be locked to one thread.
 func (s *sysSocket) do(f func()) error {
-	done := make(chan bool, 1)
-
 	// All operations handled by this function are assumed to only
 	// read from s.done.
 	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	if s.done {
-		s.mu.RUnlock()
+	if s.closed {
 		return syscall.EBADF
 	}
 
-	s.funcC <- func() {
-		f()
-		done <- true
-	}
-	<-done
-
-	s.mu.RUnlock()
-
+	s.g.run(f)
 	return nil
+}
+
+// read executes f, a read function, against the associated file descriptor.
+func (s *sysSocket) read(f func(fd int) bool) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return syscall.EBADF
+	}
+
+	var err error
+	s.g.run(func() {
+		err = fdread(s.fd, f)
+	})
+	return err
+}
+
+// write executes f, a write function, against the associated file descriptor.
+func (s *sysSocket) write(f func(fd int) bool) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return syscall.EBADF
+	}
+
+	var err error
+	s.g.run(func() {
+		err = fdwrite(s.fd, f)
+	})
+	return err
+}
+
+// control executes f, a control function, against the associated file descriptor.
+func (s *sysSocket) control(f func(fd int)) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return syscall.EBADF
+	}
+
+	var err error
+	s.g.run(func() {
+		err = fdcontrol(s.fd, f)
+	})
+	return err
 }
 
 func (s *sysSocket) Socket(family int) error {
@@ -461,14 +450,17 @@ func (s *sysSocket) Socket(family int) error {
 		return err
 	}
 
-	s.fd = fd
+	if err := setBlockingMode(fd); err != nil {
+		return err
+	}
+	s.fd = os.NewFile(uintptr(fd), "netlink")
 	return nil
 }
 
 func (s *sysSocket) Bind(sa unix.Sockaddr) error {
 	var err error
-	doErr := s.do(func() {
-		err = unix.Bind(s.fd, sa)
+	doErr := s.control(func(fd int) {
+		err = unix.Bind(fd, sa)
 	})
 	if doErr != nil {
 		return doErr
@@ -488,19 +480,18 @@ func (s *sysSocket) Close() error {
 
 	// Close the socket from the main thread, this operation has no risk
 	// of routing data to the wrong socket.
-	err := unix.Close(s.fd)
-	s.done = true
+	err := s.fd.Close()
+	s.closed = true
 
-	// Signal the syscall worker to exit, wait for the WaitGroup to join,
-	// and close the job channel only when the worker is guaranteed to have stopped.
-	close(s.doneC)
-	s.wg.Wait()
-	close(s.funcC)
+	// Stop the associated goroutine and wait for it to return.
+	s.g.stop()
 
 	return err
 }
 
-func (s *sysSocket) FD() int { return s.fd }
+func (s *sysSocket) FD() int { return int(s.fd.Fd()) }
+
+func (s *sysSocket) File() *os.File { return s.fd }
 
 func (s *sysSocket) Getsockname() (unix.Sockaddr, error) {
 	var (
@@ -508,8 +499,8 @@ func (s *sysSocket) Getsockname() (unix.Sockaddr, error) {
 		err error
 	)
 
-	doErr := s.do(func() {
-		sa, err = unix.Getsockname(s.fd)
+	doErr := s.control(func(fd int) {
+		sa, err = unix.Getsockname(fd)
 	})
 	if doErr != nil {
 		return nil, doErr
@@ -525,8 +516,19 @@ func (s *sysSocket) Recvmsg(p, oob []byte, flags int) (int, int, int, unix.Socka
 		err                error
 	)
 
-	doErr := s.do(func() {
-		n, oobn, recvflags, from, err = unix.Recvmsg(s.fd, p, oob, flags)
+	doErr := s.read(func(fd int) bool {
+		n, oobn, recvflags, from, err = unix.Recvmsg(fd, p, oob, flags)
+		if err == syscall.EAGAIN {
+			// When the socket is in non-blocking mode, we might see
+			// EAGAIN and end up here. In that case, return false to
+			// let the poller wait for readiness. See the source code
+			// for internal/poll.FD.RawRead for more details.
+			//
+			// If the socket is in blocking mode, this branch should
+			// never be taken.
+			return false
+		}
+		return true
 	})
 	if doErr != nil {
 		return 0, 0, 0, nil, doErr
@@ -537,8 +539,13 @@ func (s *sysSocket) Recvmsg(p, oob []byte, flags int) (int, int, int, unix.Socka
 
 func (s *sysSocket) Sendmsg(p, oob []byte, to unix.Sockaddr, flags int) error {
 	var err error
-	doErr := s.do(func() {
-		err = unix.Sendmsg(s.fd, p, oob, to, flags)
+	doErr := s.write(func(fd int) bool {
+		err = unix.Sendmsg(fd, p, oob, to, flags)
+		if err == syscall.EAGAIN {
+			// Analogous to Recvmsg. See the comments there.
+			return false
+		}
+		return true
 	})
 	if doErr != nil {
 		return doErr
@@ -547,14 +554,125 @@ func (s *sysSocket) Sendmsg(p, oob []byte, to unix.Sockaddr, flags int) error {
 	return err
 }
 
+func (s *sysSocket) SetDeadline(t time.Time) error {
+	return s.fd.SetDeadline(t)
+}
+
+func (s *sysSocket) SetReadDeadline(t time.Time) error {
+	return s.fd.SetReadDeadline(t)
+}
+
+func (s *sysSocket) SetWriteDeadline(t time.Time) error {
+	return s.fd.SetWriteDeadline(t)
+}
+
 func (s *sysSocket) SetSockopt(level, name int, v unsafe.Pointer, l uint32) error {
 	var err error
-	doErr := s.do(func() {
-		err = setsockopt(s.fd, level, name, v, l)
+	doErr := s.control(func(fd int) {
+		err = setsockopt(fd, level, name, v, l)
 	})
 	if doErr != nil {
 		return doErr
 	}
 
 	return err
+}
+
+// lockedNetNSGoroutine is a worker goroutine locked to an operating system
+// thread, optionally configured to run in a non-default network namespace.
+type lockedNetNSGoroutine struct {
+	wg    sync.WaitGroup
+	doneC chan struct{}
+	funcC chan func()
+}
+
+func newLockedNetNSGoroutine(netNS int) (*lockedNetNSGoroutine, error) {
+	g := &lockedNetNSGoroutine{
+		doneC: make(chan struct{}),
+		funcC: make(chan func()),
+	}
+
+	errC := make(chan error)
+	g.wg.Add(1)
+
+	go func() {
+		// It is important to lock this goroutine to its OS thread for the duration
+		// of the netlink socket being used, or else the kernel may end up routing
+		// messages to the wrong places.
+		// See: http://lists.infradead.org/pipermail/libnl/2017-February/002293.html.
+		//
+		// The intent is to never unlock the OS thread, so that the thread
+		// will terminate when the goroutine exits starting in Go 1.10:
+		// https://go-review.googlesource.com/c/go/+/46038.
+		//
+		// However, due to recent instability and a potential bad interaction
+		// with the Go runtime for threads which are not unlocked, we have
+		// elected to temporarily unlock the thread when the goroutine terminates:
+		// https://github.com/golang/go/issues/25128#issuecomment-410764489.
+
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		defer g.wg.Done()
+
+		// The user requested the Conn to operate in a non-default network namespace.
+		if netNS != 0 {
+
+			// Get the current namespace of the thread the goroutine is locked to.
+			origNetNS, err := getThreadNetNS()
+			if err != nil {
+				errC <- err
+				return
+			}
+
+			// Set the network namespace of the current thread using
+			// the file descriptor provided by the user.
+			err = setThreadNetNS(netNS)
+			if err != nil {
+				errC <- err
+				return
+			}
+
+			// Once the thread's namespace has been successfully manipulated,
+			// make sure we change it back when the goroutine returns.
+			defer setThreadNetNS(origNetNS)
+		}
+
+		// Signal to caller that initialization was successful.
+		errC <- nil
+
+		for {
+			select {
+			case <-g.doneC:
+				return
+			case f := <-g.funcC:
+				f()
+			}
+		}
+	}()
+
+	// Wait for the goroutine to return err or nil.
+	if err := <-errC; err != nil {
+		return nil, err
+	}
+
+	return g, nil
+}
+
+// stop signals the goroutine to stop and blocks until it does.
+//
+// It is invalid to call run concurrently with stop. It is also invalid to
+// call run after stop has returned.
+func (g *lockedNetNSGoroutine) stop() {
+	close(g.doneC)
+	g.wg.Wait()
+}
+
+// run runs f on the worker goroutine.
+func (g *lockedNetNSGoroutine) run(f func()) {
+	done := make(chan struct{})
+	g.funcC <- func() {
+		defer close(done)
+		f()
+	}
+	<-done
 }

--- a/conn_linux_gteq_1.12_integration_test.go
+++ b/conn_linux_gteq_1.12_integration_test.go
@@ -1,0 +1,80 @@
+//+build tip
+
+package netlink_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/mdlayher/netlink"
+)
+
+func TestConnReadTimeout(t *testing.T) {
+	const family = 15 // NETLINK_KOBJECT_UEVENT
+	conn, err := netlink.Dial(family, nil)
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Hopefully, no events are happening just as this test is running.
+	// Use a reasonably small interval.
+	//
+	// TODO(acln): perhaps there is a better way to write this test
+	timeout := 1 * time.Millisecond
+	if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		t.Fatalf("failed to set deadline: %v", err)
+	}
+
+	errC := make(chan error)
+	go func() {
+		_, err := conn.Receive()
+		errC <- err
+	}()
+
+	select {
+	case err := <-errC:
+		mustBeTimeoutNetError(t, err)
+	case <-time.After(timeout + 1*time.Millisecond):
+		t.Fatalf("timeout did not fire")
+	}
+}
+
+func TestConnExecuteAfterReadDeadline(t *testing.T) {
+	const family = 16 // NETLINK_GENERIC
+	conn, err := netlink.Dial(family, nil)
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer conn.Close()
+
+	timeout := 1 * time.Millisecond
+	if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		t.Fatalf("failed to set deadline: %v", err)
+	}
+	time.Sleep(2 * timeout)
+
+	req := netlink.Message{
+		Header: netlink.Header{
+			Flags:    netlink.HeaderFlagsRequest | netlink.HeaderFlagsAcknowledge,
+			Sequence: 1,
+		},
+	}
+	got, err := conn.Execute(req)
+	if err == nil {
+		t.Fatalf("Execute succeeded: got %v", got)
+	}
+	mustBeTimeoutNetError(t, err)
+}
+
+func mustBeTimeoutNetError(t *testing.T, err error) {
+	t.Helper()
+	ne, ok := err.(net.Error)
+	if !ok {
+		t.Fatalf("didn't get a net.Error: got a %T instead", err)
+	}
+	if !ne.Timeout() {
+		t.Fatalf("didn't get a timeout")
+	}
+}

--- a/conn_linux_test.go
+++ b/conn_linux_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"syscall"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/google/go-cmp/cmp"
@@ -733,7 +734,11 @@ type testSocket struct {
 		recvflags int
 		from      unix.Sockaddr
 	}
-	setSockopt []setSockopt
+	// TODO(acln): use these next three fields in tests
+	deadline      time.Time
+	readDeadline  time.Time
+	writeDeadline time.Time
+	setSockopt    []setSockopt
 }
 
 type setSockopt struct {
@@ -754,6 +759,8 @@ func (s *testSocket) Close() error {
 }
 
 func (s *testSocket) FD() int { return 0 }
+
+func (s *testSocket) File() *os.File { return nil }
 
 func (s *testSocket) Getsockname() (unix.Sockaddr, error) {
 	if s.getsockname == nil {
@@ -776,6 +783,21 @@ func (s *testSocket) Sendmsg(p, oob []byte, to unix.Sockaddr, flags int) error {
 	s.sendmsg.oob = oob
 	s.sendmsg.to = to
 	s.sendmsg.flags = flags
+	return nil
+}
+
+func (s *testSocket) SetDeadline(t time.Time) error {
+	s.deadline = t
+	return nil
+}
+
+func (s *testSocket) SetReadDeadline(t time.Time) error {
+	s.readDeadline = t
+	return nil
+}
+
+func (s *testSocket) SetWriteDeadline(t time.Time) error {
+	s.writeDeadline = t
 	return nil
 }
 

--- a/fdcall_gteq_1.12.go
+++ b/fdcall_gteq_1.12.go
@@ -1,0 +1,48 @@
+//+build tip
+
+package netlink
+
+import (
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func setBlockingMode(sysfd int) error {
+	return unix.SetNonblock(sysfd, true)
+}
+
+func fdread(fd *os.File, f func(int) (done bool)) error {
+	rc, err := fd.SyscallConn()
+	if err != nil {
+		return err
+	}
+	return rc.Read(func(sysfd uintptr) bool {
+		return f(int(sysfd))
+	})
+}
+
+func fdwrite(fd *os.File, f func(int) (done bool)) error {
+	rc, err := fd.SyscallConn()
+	if err != nil {
+		return err
+	}
+	return rc.Write(func(sysfd uintptr) bool {
+		return f(int(sysfd))
+	})
+}
+
+func fdcontrol(fd *os.File, f func(int)) error {
+	rc, err := fd.SyscallConn()
+	if err != nil {
+		return err
+	}
+	return rc.Control(func(sysfd uintptr) {
+		f(int(sysfd))
+	})
+}
+
+func newRawConn(fd *os.File) (syscall.RawConn, error) {
+	return fd.SyscallConn()
+}

--- a/fdcall_lt_1.12.go
+++ b/fdcall_lt_1.12.go
@@ -1,0 +1,48 @@
+//+build !tip
+
+package netlink
+
+import (
+	"os"
+	"syscall"
+)
+
+func setBlockingMode(sysfd int) error {
+	return nil
+}
+
+func fdread(fd *os.File, f func(int) (done bool)) error {
+	f(int(fd.Fd()))
+	return nil
+}
+
+func fdwrite(fd *os.File, f func(int) (done bool)) error {
+	f(int(fd.Fd()))
+	return nil
+}
+
+func fdcontrol(fd *os.File, f func(int)) error {
+	f(int(fd.Fd()))
+	return nil
+}
+
+func newRawConn(fd *os.File) (syscall.RawConn, error) {
+	return &rawConn{fd: fd.Fd()}, nil
+}
+
+var _ syscall.RawConn = &rawConn{}
+
+// A rawConn is a syscall.RawConn.
+type rawConn struct {
+	fd uintptr
+}
+
+func (rc *rawConn) Control(f func(fd uintptr)) error {
+	f(rc.fd)
+	return nil
+}
+
+// TODO(mdlayher): implement Read and Write?
+
+func (rc *rawConn) Read(_ func(fd uintptr) (done bool)) error  { return errSyscallConnNotSupported }
+func (rc *rawConn) Write(_ func(fd uintptr) (done bool)) error { return errSyscallConnNotSupported }


### PR DESCRIPTION
WORK IN PROGRESS

Factor out goroutine management logic from sysSocket. Add a new
lockedNetNSGoroutine type, representing a goroutine
which executes code on a specific operating system thread.
As its name suggests, a lockedNetNSGoroutine can be configured to
operate in a non-default network namespace.

Add read, write, and control methods to sysSocket, which add more
context and semantics at previous call sites of (*sysSocket).do.

Switch sysSocket to use an *os.File internally, instead of an
integer file descriptor. Use the poller to make calls against
the socket. Add Set{Deadline,ReadDeadline,WriteDeadline} methods to
Conn.

Add tests to verify that read deadlines work.

---

Hey @acln0, now that draft PRs are a thing, I'm opening this up so more folks can see it! In addition, I'll have a commit for you to review shortly that fixes the merge problem I just created with #121.