### PR TITLE
netlink: serialize calls to Conn.Execute, lock in concurrency behaviors

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -236,7 +236,7 @@ func (c *Conn) Receive() ([]Message, error) {
 	return c.lockedReceive()
 }
 
-// lockedSend implements Receive, but must be called with c.mu acquired for reading.
+// lockedReceive implements Receive, but must be called with c.mu acquired for reading.
 // We rely on the kernel to deal with concurrent reads and writes to the netlink
 // socket itself.
 func (c *Conn) lockedReceive() ([]Message, error) {

--- a/conn_linux_integration_test.go
+++ b/conn_linux_integration_test.go
@@ -169,7 +169,7 @@ func TestLinuxConnIntegrationConcurrentReceiveClose(t *testing.T) {
 		// Expect an error due to file descriptor being closed.
 		serr := err.(*netlink.OpError).Err.(*os.SyscallError).Err
 		if diff := cmp.Diff(unix.EBADF, serr); diff != "" {
-			t.Fatalf("unexpected error from receive (-want +got):\n%s", diff)
+			panicf("unexpected error from receive (-want +got):\n%s", diff)
 		}
 	}()
 

--- a/conn_linux_integration_test.go
+++ b/conn_linux_integration_test.go
@@ -181,7 +181,7 @@ func TestLinuxConnIntegrationConcurrentReceiveClose(t *testing.T) {
 func TestLinuxConnIntegrationConcurrentSerializeExecute(t *testing.T) {
 	c, err := netlink.Dial(unix.NETLINK_GENERIC, nil)
 	if err != nil {
-		panicf("failed to dial netlink: %v", err)
+		t.Fatalf("failed to dial netlink: %v", err)
 	}
 
 	execN := func(n int) {
@@ -301,7 +301,7 @@ func TestLinuxConnIntegrationSetBuffersSyscallConn(t *testing.T) {
 func TestLinuxConnIntegrationSetBPF(t *testing.T) {
 	c, err := netlink.Dial(unix.NETLINK_GENERIC, nil)
 	if err != nil {
-		t.Fatalf("failed to dial: %v", err)
+		t.Fatalf("failed to dial netlink: %v", err)
 	}
 	defer c.Close()
 
@@ -429,12 +429,11 @@ func testBPFProgram(allowSequence uint32) []bpf.Instruction {
 }
 
 func TestLinuxConnIntegrationMulticast(t *testing.T) {
-
 	c, err := netlink.Dial(unix.NETLINK_ROUTE, &netlink.Config{
 		Groups: 0x1, // RTMGRP_LINK
 	})
 	if err != nil {
-		t.Fatalf("failed to dial: %v", err)
+		t.Fatalf("failed to dial netlink: %v", err)
 	}
 
 	in := make(chan []netlink.Message)


### PR DESCRIPTION
This enables and verifies:

- many concurrent calls to Send/Receive, relying on the kernel to deal with socket concurrency
- serialized calls to Execute, to verify that individual request/response pairs actually line up (the most common use case)
- Receive and other calls can always be unblocked by Close