### PR TITLE
netlink: append to Receive buffer instead of allocating a new one

### DIFF
--- a/conn_linux.go
+++ b/conn_linux.go
@@ -154,7 +154,7 @@ func (c *conn) Receive() ([]Message, error) {
 		}
 
 		// Double in size if not enough bytes
-		b = make([]byte, len(b)*2)
+		b = append(b, make([]byte, len(b))...)
 	}
 
 	// Read out all available messages


### PR DESCRIPTION
I'd like a bit of a sanity check here, but this is surely the better approach, right? If I understand, previously I was totally discarding the bytes of `b` and allocating a brand new slice every time, instead of appending to the existing one.