### PR TITLE
Add socket option NETLINK_EXT_ACK

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -428,6 +428,7 @@ const (
 	NoENOBUFS
 	ListenAllNSID
 	CapAcknowledge
+	ExtendAckReporting
 )
 
 // An optionSetter is a Socket that supports setting netlink options.

--- a/conn.go
+++ b/conn.go
@@ -428,7 +428,7 @@ const (
 	NoENOBUFS
 	ListenAllNSID
 	CapAcknowledge
-	ExtendAckReporting
+	ExtendedAcknowledge
 )
 
 // An optionSetter is a Socket that supports setting netlink options.

--- a/conn_linux.go
+++ b/conn_linux.go
@@ -305,7 +305,7 @@ func linuxOption(o ConnOption) (int, bool) {
 		return unix.NETLINK_LISTEN_ALL_NSID, true
 	case CapAcknowledge:
 		return unix.NETLINK_CAP_ACK, true
-	case ExtendAckReporting:
+	case ExtendedAcknowledge:
 		return unix.NETLINK_EXT_ACK, true
 	default:
 		return 0, false

--- a/conn_linux.go
+++ b/conn_linux.go
@@ -305,6 +305,8 @@ func linuxOption(o ConnOption) (int, bool) {
 		return unix.NETLINK_LISTEN_ALL_NSID, true
 	case CapAcknowledge:
 		return unix.NETLINK_CAP_ACK, true
+	case ExtendAckReporting:
+		return unix.NETLINK_EXT_ACK, true
 	default:
 		return 0, false
 	}

--- a/conn_linux_test.go
+++ b/conn_linux_test.go
@@ -370,6 +370,15 @@ func TestLinuxConnSetOption(t *testing.T) {
 				value: 1,
 			},
 		},
+		{
+			name:   "extended ACK reporting",
+			option: ExtendAckReporting,
+			enable: true,
+			want: setSockopt{
+				opt:   unix.NETLINK_EXT_ACK,
+				value: 1,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/conn_linux_test.go
+++ b/conn_linux_test.go
@@ -372,7 +372,7 @@ func TestLinuxConnSetOption(t *testing.T) {
 		},
 		{
 			name:   "extended ACK reporting",
-			option: ExtendAckReporting,
+			option: ExtendedAcknowledge,
 			enable: true,
 			want: setSockopt{
 				opt:   unix.NETLINK_EXT_ACK,


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

This PR adds support for the socket option NETLINK_EXT_ACK. 

https://lwn.net/Articles/719721/