### PR TITLE
netlink: add CallingThreadNetNS to enter caller's network namespace

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -569,6 +569,11 @@ const (
 	// network namespaces. See the documentation of runtime.LockOSThread and
 	// runtime.UnlockOSThread for details.
 	//
+	// A Conn is capable of entering a specific network namespace on its own,
+	// without any OS thread locking by the caller, but this option is useful
+	// for cases where the caller has already locked the calling OS thread and
+	// manipulated the network namespace of the calling thread.
+	//
 	// This option is useful in very specific circumstances, and must be used
 	// with great care.
 	CallingThreadNetNS = -1


### PR DESCRIPTION
This is a little bit tricky.

A user has created an application which locks OS thread and enters its own network namespace before using `wgctrl.New()` to manipulate WireGuard devices in that namespace. Because wgctrl is backed by this package but provides no explicit tunable at the moment to enter a namespace via the netlink connection, it would seem the correct behavior is to automatically inherit the calling thread's network namespace in the new goroutine.

I'm not an expert on namespaces, but I believe this change to be backward compatible. The majority of callers who are not specifying NetNS today expect to inherit the network namespace of the calling process. This should account for that use case, as well as that of a caller who has manipulated the calling goroutine's thread into another namespace as well.