### PR TITLE
netlink: add netNS type for network namespace manipulation

### DIFF
--- a/conn_linux_gteq_1.12_integration_test.go
+++ b/conn_linux_gteq_1.12_integration_test.go
@@ -162,18 +162,31 @@ func TestIntegrationConnNetNSImplicit(t *testing.T) {
 	}
 	defer threadNS.Close()
 
-	defer func() {
-		if err := threadNS.Restore(); err != nil {
-			t.Fatalf("failed to restore original network namespace: %v", err)
-		}
-	}()
-
 	if err := threadNS.Set(int(f.Fd())); err != nil {
 		t.Fatalf("failed to enter new network namespace: %v", err)
 	}
 
-	// Any netlink connections created beyond this point should set themselves
-	// into the new namespace automatically as well.
+	// A newly created netlink connection should enter the new network namespace
+	// associated with this thread automatically.
+	if !findLink(t, ifName) {
+		t.Fatalf("did not find interface %q in namespace %q", ifName, ns)
+	}
+
+	// Return to the default namespace.
+	//
+	// A newly created netlink connection should NOT find the link because it
+	// is now in the default namespace.
+	if err := threadNS.Restore(); err != nil {
+		t.Fatalf("failed to restore original network namespace: %v", err)
+	}
+
+	if findLink(t, ifName) {
+		t.Fatalf("found interface %q in default namespace", ifName)
+	}
+}
+
+func findLink(t *testing.T, name string) bool {
+	t.Helper()
 
 	c, err := rtnl.Dial(nil)
 	if err != nil {
@@ -188,15 +201,13 @@ func TestIntegrationConnNetNSImplicit(t *testing.T) {
 
 	var found bool
 	for _, ifi := range ifis {
-		if ifi.Name == ifName {
+		if ifi.Name == name {
 			found = true
 			break
 		}
 	}
 
-	if !found {
-		t.Fatalf("did not find interface %q in namespace %q", ifName, ns)
-	}
+	return found
 }
 
 func mustBeTimeoutNetError(t *testing.T, err error) {

--- a/conn_linux_gteq_1.12_integration_test.go
+++ b/conn_linux_gteq_1.12_integration_test.go
@@ -156,18 +156,19 @@ func TestIntegrationConnNetNSImplicit(t *testing.T) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	origNS, err := netlink.GetThreadNetNS()
+	threadNS, err := netlink.ThreadNetNS()
 	if err != nil {
 		t.Fatalf("failed to get current network namespace: %v", err)
 	}
+	defer threadNS.Close()
 
 	defer func() {
-		if err := netlink.SetThreadNetNS(origNS); err != nil {
+		if err := threadNS.Restore(); err != nil {
 			t.Fatalf("failed to restore original network namespace: %v", err)
 		}
 	}()
 
-	if err := netlink.SetThreadNetNS(int(f.Fd())); err != nil {
+	if err := threadNS.Set(int(f.Fd())); err != nil {
 		t.Fatalf("failed to enter new network namespace: %v", err)
 	}
 

--- a/export_linux_test.go
+++ b/export_linux_test.go
@@ -4,8 +4,17 @@ package netlink
 
 // This file exports certain identifiers for use in tests.
 
-// GetThreadNetNS wraps the internal getThreadNetNS for use in tests.
-func GetThreadNetNS() (int, error) { return getThreadNetNS() }
+// A NetNS wraps an internal netNS.
+type NetNS struct {
+	*netNS
+}
 
-// SetThreadNetNS wraps the internal setThreadNetNS for use in tests.
-func SetThreadNetNS(fd int) error { return setThreadNetNS(fd) }
+// ThreadNetNS wraps the internal threadNetNS.
+func ThreadNetNS() (*NetNS, error) {
+	ns, err := threadNetNS()
+	if err != nil {
+		return nil, err
+	}
+
+	return &NetNS{netNS: ns}, nil
+}


### PR DESCRIPTION
I was a little leery of directly opening files and passing back the file descriptor without managing the entire lifetime of the file (how long does it continue to live?), so I decided to evaluate things a bit more and see what I could come up with.

The netNS type is a wrapper around network namespace operations which hopefully makes things clear and makes the lifetime of these network namespace files easy to reason about.