### PR TITLE
Provide configuration option for not locking go-routines to threads

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -593,7 +593,6 @@ type Config struct {
 	// impact. In these cases, the caller can disable thread locking if performance
 	// considerations are of interest. If disabled, it is the responsibility of
 	// the caller to make sure that all threads are running in the correct namespace.
-	// When DisableNSLockThread is set, the caller cannot set the NetNS value. An error
-	// will be returned.
+	// When DisableNSLockThread is set, the caller cannot set the NetNS value.
 	DisableNSLockThread bool
 }

--- a/conn.go
+++ b/conn.go
@@ -584,16 +584,16 @@ type Config struct {
 	// to 0.
 	NetNS int
 
-	// DisableNSLockThread
+	// DisableNSLockThread disables package netlink's default goroutine thread locking behavior.
 	//
-	// By default, the library will lock the processing go routine to its corresponding
+	// By default, the library will lock the processing goroutine to its corresponding
 	// thread in order to enable communication over netlink to a different namespaces.
 	// In some cases, where the caller already knows that the netlink socket
 	// is in the same namespace as the calling thread, this can introduce a performance
 	// impact. In these cases, the caller can disable thread locking if performance
-	// consideration are of interest. If disabled, it is the responsibility of
+	// considerations are of interest. If disabled, it is the responsibility of
 	// the caller to make sure that all threads are running in the correct namespace.
-	// When DisabeNSLockThread is set, the caller cannot set the NetNS value. An error
+	// When DisableNSLockThread is set, the caller cannot set the NetNS value. An error
 	// will be returned.
 	DisableNSLockThread bool
 }

--- a/conn.go
+++ b/conn.go
@@ -583,4 +583,17 @@ type Config struct {
 	// CAP_SYS_ADMIN are required), and most applications should leave this set
 	// to 0.
 	NetNS int
+
+	// DisableNSLockThread
+	//
+	// By default, the library will lock the processing go routine to its corresponding
+	// thread in order to enable communication over netlink to a different namespaces.
+	// In some cases, where the caller already knows that the netlink socket
+	// is in the same namespace as the calling thread, this can introduce a performance
+	// impact. In these cases, the caller can disable thread locking if performance
+	// consideration are of interest. If disabled, it is the responsibility of
+	// the caller to make sure that all threads are running in the correct namespace.
+	// When DisabeNSLockThread is set, the caller cannot set the NetNS value. An error
+	// will be returned.
+	DisableNSLockThread bool
 }

--- a/conn_linux.go
+++ b/conn_linux.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var errInvalidConfiguration = errors.New("Netns cannot be set when disableNSThreadLock is set")
+var errInvalidConfiguration = errors.New("netns cannot be set when disableNSThreadLock is set")
 
 var _ Socket = &conn{}
 

--- a/conn_linux.go
+++ b/conn_linux.go
@@ -3,6 +3,7 @@
 package netlink
 
 import (
+	"errors"
 	"math"
 	"os"
 	"runtime"
@@ -14,6 +15,8 @@ import (
 	"golang.org/x/net/bpf"
 	"golang.org/x/sys/unix"
 )
+
+var errInvalidConfiguration = errors.New("Netns cannot be set when disableNSThreadLock is set")
 
 var _ Socket = &conn{}
 
@@ -339,7 +342,7 @@ type sysSocket struct {
 // to a single thread.
 func newSysSocket(config *Config) (*sysSocket, error) {
 	// Determine network namespaces using the threadNetNS function.
-	g, err := newLockedNetNSGoroutine(config.NetNS, threadNetNS)
+	g, err := newLockedNetNSGoroutine(config.NetNS, threadNetNS, config.DisableNSLockThread)
 	if err != nil {
 		return nil, err
 	}
@@ -624,9 +627,15 @@ type lockedNetNSGoroutine struct {
 // newLockedNetNSGoroutine creates a lockedNetNSGoroutine that will enter the
 // specified network namespace netNS (by file descriptor), and will use the
 // getNS function to produce netNS handles.
-func newLockedNetNSGoroutine(netNS int, getNS func() (*netNS, error)) (*lockedNetNSGoroutine, error) {
+func newLockedNetNSGoroutine(netNS int, getNS func() (*netNS, error), disableThreadLock bool) (*lockedNetNSGoroutine, error) {
 	// Any bare syscall errors (e.g. setns) should be wrapped with
 	// os.NewSyscallError for the remainder of this function.
+
+	// If the disableThreadLock is set and the caller attempts to set a
+	// namespace, return an error.
+	if disableThreadLock && netNS != 0 {
+		return nil, errInvalidConfiguration
+	}
 
 	callerNS, err := getNS()
 	if err != nil {
@@ -660,9 +669,19 @@ func newLockedNetNSGoroutine(netNS int, getNS func() (*netNS, error)) (*lockedNe
 		// with the Go runtime for threads which are not unlocked, we have
 		// elected to temporarily unlock the thread when the goroutine terminates:
 		// https://github.com/golang/go/issues/25128#issuecomment-410764489.
+		//
+		// Locking the thread is not implemented if the caller explicitly asks
+		// for an unlocked thread, since the caller can guarantee that there
+		// is no namespace switching and the master process is running in the
+		// same namespace as the target namespace. In this case, the configuration
+		// must not attempt to switch namespaces explicitly.
 
-		runtime.LockOSThread()
-		defer runtime.UnlockOSThread()
+		// Only lock the tread, if the disableThreadLock is not set.
+		if !disableThreadLock {
+			runtime.LockOSThread()
+			defer runtime.UnlockOSThread()
+		}
+
 		defer g.wg.Done()
 
 		// Get the current namespace of the thread the goroutine is locked to.

--- a/conn_linux.go
+++ b/conn_linux.go
@@ -671,10 +671,7 @@ func newLockedNetNSGoroutine(netNS int, getNS func() (*netNS, error), disableThr
 		// https://github.com/golang/go/issues/25128#issuecomment-410764489.
 		//
 		// Locking the thread is not implemented if the caller explicitly asks
-		// for an unlocked thread, since the caller can guarantee that there
-		// is no namespace switching and the master process is running in the
-		// same namespace as the target namespace. In this case, the configuration
-		// must not attempt to switch namespaces explicitly.
+		// for an unlocked thread.
 
 		// Only lock the tread, if the disableThreadLock is not set.
 		if !disableThreadLock {

--- a/conn_linux.go
+++ b/conn_linux.go
@@ -673,8 +673,8 @@ func newLockedNetNSGoroutine(netNS int, getNS func() (*netNS, error), lockThread
 		// Locking the thread is not implemented if the caller explicitly asks
 		// for an unlocked thread.
 
-		// Only lock the tread, if the disableThreadLock is not set.
-		if !disableThreadLock {
+		// Only lock the tread, if the lockThread is set.
+		if lockThread {
 			runtime.LockOSThread()
 			defer runtime.UnlockOSThread()
 		}

--- a/conn_linux.go
+++ b/conn_linux.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var errNetNSDisabled = errors.New("netns cannot be set when disableNSThreadLock is set")
+var errNetNSCannotLockThread = errors.New("netns cannot be set when disableNSThreadLock is set")
 
 var _ Socket = &conn{}
 
@@ -634,7 +634,7 @@ func newLockedNetNSGoroutine(netNS int, getNS func() (*netNS, error), lockThread
 	// If the lockThread is set and the caller attempts to set a
 	// namespace, return an error.
 	if lockThread && netNS != 0 {
-		return nil, errNetNSDisabled
+		return nil, errNetNSCannotLockThread
 	}
 
 	callerNS, err := getNS()

--- a/conn_linux.go
+++ b/conn_linux.go
@@ -633,7 +633,7 @@ func newLockedNetNSGoroutine(netNS int, getNS func() (*netNS, error), lockThread
 
 	// If the lockThread is set and the caller attempts to set a
 	// namespace, return an error.
-	if lockThread && netNS != 0 {
+	if !lockThread && netNS != 0 {
 		return nil, errNetNSCannotLockThread
 	}
 

--- a/conn_linux_test.go
+++ b/conn_linux_test.go
@@ -510,36 +510,38 @@ func TestLinuxConnConfig(t *testing.T) {
 
 func Test_newLockedNetNSGoroutineNetNSDisabled(t *testing.T) {
 	tests := []struct {
-		name                string
-		ns                  int
-		ok                  bool
-		disableNSLockThread bool
+		name       string
+		ns         int
+		ok         bool
+		lockThread bool
 	}{
 		{
 			// Network namespaces are disabled but none is set: this should
 			// succeed.
-			name: "not set",
-			ok:   true,
+			name:       "not set",
+			ok:         true,
+			lockThread: true,
 		},
 		{
 			// Network namespaces are disabled but one is set explicitly:
 			// this should fail.
-			name: "set",
-			ns:   1,
+			name:       "set",
+			ns:         1,
+			lockThread: true,
 		},
 		{
 			// thread locking is disabled but an ns is provided.
 			// this should fail.
-			name:                "disable lock thread with ns defined",
-			ns:                  1,
-			disableNSLockThread: true,
+			name:       "disable lock thread with ns defined",
+			ns:         1,
+			lockThread: false,
 		},
 		{
 			// thread locking is disabled but an ns is not provided.
 			// this should succeed.
-			name:                "disable lock thread without ns defined",
-			disableNSLockThread: true,
-			ok:                  true,
+			name:       "disable lock thread without ns defined",
+			lockThread: false,
+			ok:         true,
 		},
 	}
 
@@ -549,7 +551,7 @@ func Test_newLockedNetNSGoroutineNetNSDisabled(t *testing.T) {
 				// Network namespaces should be disabled due to a non-existent
 				// file.
 				return fileNetNS("/netlinktestdoesnotexist")
-			}, true)
+			}, tt.lockThread)
 			if err != nil {
 				if tt.ok {
 					t.Fatalf("failed to create goroutine: %v", err)

--- a/conn_linux_test.go
+++ b/conn_linux_test.go
@@ -549,7 +549,7 @@ func Test_newLockedNetNSGoroutineNetNSDisabled(t *testing.T) {
 				// Network namespaces should be disabled due to a non-existent
 				// file.
 				return fileNetNS("/netlinktestdoesnotexist")
-			}, false)
+			}, true)
 			if err != nil {
 				if tt.ok {
 					t.Fatalf("failed to create goroutine: %v", err)


### PR DESCRIPTION
This is an implementation of the configuration option that will allow callers to 
define that the thread lock must be bypassed. 

See discussion here for details: https://github.com/mdlayher/netlink/issues/146