### PR TITLE
add IsExist() function

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -44,6 +44,17 @@ func IsNotExist(err error) bool {
 	}
 }
 
+// IsExist is similar to IsNotExist but checks whether the error is known to report that an object already exists,
+// e.g. an address is already assigned to an interface.
+func IsExist(err error) bool {
+	switch err := err.(type) {
+	case *OpError:
+		return os.IsExist(err.Err)
+	default:
+		return os.IsExist(err)
+	}
+}
+
 var _ error = &OpError{}
 var _ net.Error = &OpError{}
 

--- a/errors_linux_test.go
+++ b/errors_linux_test.go
@@ -67,3 +67,24 @@ func TestIsNotExistLinux(t *testing.T) {
 		})
 	}
 }
+
+func TestIsExistLinux(t *testing.T) {
+	var testcases = []struct {
+		in  error
+		out bool
+	}{
+		{in: nil, out: false},
+		{in: &netlink.OpError{Op: "receive", Err: os.ErrExist}, out: true},
+		{in: &netlink.OpError{Op: "receive", Err: os.ErrPermission}, out: false},
+		{in: &netlink.OpError{Op: "receive", Err: os.ErrNotExist}, out: false},
+		{in: os.ErrExist, out: true},
+		{in: os.ErrPermission, out: false},
+		{in: os.ErrNotExist, out: false},
+	}
+	for i, tc := range testcases {
+		out := netlink.IsExist(tc.in)
+		if out != tc.out {
+			t.Errorf("'%v' (#%d): expected %#v, got %#v", tc.in, i, tc.out, out)
+		}
+	}
+}


### PR DESCRIPTION
_IsExist_ comes handy when, say, checking the result of `RTM_NEWADDR`, and decide to proceed if the system failed to add address just because it's already there. Allows to skip scanning for existing addresses before attempting to add one, as the system shall do the same on its side.

cc @mdlayher @jsimonetti 