### PR TITLE
Implements errors.Wrapper interface for OpError

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -84,6 +84,11 @@ func (e *OpError) Error() string {
 	return fmt.Sprintf("netlink %s: %v", e.Op, e.Err)
 }
 
+// Unwrap implements errors.Wrapper interface
+func (e *OpError) Unwrap() error {
+	return e.Err
+}
+
 // Portions of this code taken from the Go standard library:
 //
 // Copyright 2009 The Go Authors. All rights reserved.


### PR DESCRIPTION
Use the new [error inspection](https://go.googlesource.com/proposal/+/master/design/29934-error-values.md) made available in Go 1.13. Follows the suggested upgrade path [outlined in the FAQ](https://github.com/golang/go/wiki/ErrorValueFAQ#i-have-a-type-that-implements-error-and-holds-a-nested-error-how-should-i-adapt-it-to-the-new-features).
Effectively, renders `IsNotExist()` obsolete (kept to avoid breaking existing clients) and saves the need to add new ones (like PR #148).  Resolves issue #130 