### PR TITLE
Add NLA_FLAG

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -282,11 +282,7 @@ func (ad *AttributeDecoder) Uint64() uint64 {
 
 // Flag returns a boolean representing the Attribute.
 func (ad *AttributeDecoder) Flag() bool {
-	if ad.err != nil {
-		return false
-	}
-
-	return true
+	return ad.err == nil
 }
 
 // Do is a general purpose function which allows access to the current data
@@ -398,7 +394,7 @@ func (ae *AttributeEncoder) Flag(typ uint16, v bool) {
 	if ae.err != nil {
 		return
 	}
-	if v == false {
+	if !v {
 		return
 	}
 

--- a/attribute.go
+++ b/attribute.go
@@ -280,6 +280,15 @@ func (ad *AttributeDecoder) Uint64() uint64 {
 	return ad.ByteOrder.Uint64(b)
 }
 
+// Flag returns a boolean representing the Attribute.
+func (ad *AttributeDecoder) Flag() bool {
+	if ad.err != nil {
+		return false
+	}
+
+	return true
+}
+
 // Do is a general purpose function which allows access to the current data
 // pointed to by the AttributeDecoder.
 //
@@ -382,6 +391,18 @@ func (ae *AttributeEncoder) Uint64(typ uint16, v uint64) {
 		Type: typ,
 		Data: b,
 	})
+}
+
+// Flag encodes a flag into an Attribute specidied by typ.
+func (ae *AttributeEncoder) Flag(typ uint16, v bool) {
+	if ae.err != nil {
+		return
+	}
+	if v == false {
+		return
+	}
+
+	ae.attrs = append(ae.attrs, Attribute{Type: typ})
 }
 
 // String encodes string s as a null-terminated string into an Attribute

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -576,6 +576,24 @@ func TestAttributeDecoderOK(t *testing.T) {
 			},
 		},
 		{
+			name: "flag",
+			attrs: []Attribute{{
+				Type: 1,
+			}},
+			fn: func(ad *AttributeDecoder) {
+				var flag bool
+				switch t := ad.Type(); t {
+				case 1:
+					flag = ad.Flag()
+				default:
+					panicf("unhandled attribute type: %d", t)
+				}
+				if flag != true {
+					panicf("unexpected attribute value (-want +got):\n -want: true\n +got: false")
+				}
+			},
+		},
+		{
 			name: "do",
 			attrs: []Attribute{
 				// Arbitrary C-like structure.
@@ -804,6 +822,20 @@ func TestAttributeEncoderOK(t *testing.T) {
 			attrs:  adEndianAttrs(binary.BigEndian),
 			endian: binary.BigEndian,
 			fn:     aeEndianTest(binary.BigEndian),
+		},
+		{
+			name:  "flag true",
+			attrs: []Attribute{{Type: 1}},
+			fn: func(ae *AttributeEncoder) {
+				ae.Flag(1, true)
+			},
+		},
+		{
+			name:  "flag false",
+			attrs: []Attribute{},
+			fn: func(ae *AttributeEncoder) {
+				ae.Flag(1, false)
+			},
 		},
 		{
 			name: "string",


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

This PR adds the attribute type NLA_FLAG.

NLA_FLAG does not hold data. It is used in the net/tipc netlink family.