### PR TITLE
Add select

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -49,6 +49,7 @@ type Socket interface {
 	Send(m Message) error
 	SendMessages(m []Message) error
 	Receive() ([]Message, error)
+	Select() (int, error)
 }
 
 // Dial dials a connection to netlink, using the specified netlink family.
@@ -317,6 +318,11 @@ func (c *Conn) receive() ([]Message, error) {
 			return res, nil
 		}
 	}
+}
+
+// Select allow to check whether netlink messages are available
+func (c *Conn) Select() (int, error) {
+	return c.sock.Select()
 }
 
 // A groupJoinLeaver is a Socket that supports joining and leaving

--- a/conn.go
+++ b/conn.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"golang.org/x/net/bpf"
+	"golang.org/x/sys/unix"
 )
 
 // A Conn is a connection to netlink.  A Conn can be used to send and
@@ -49,7 +50,7 @@ type Socket interface {
 	Send(m Message) error
 	SendMessages(m []Message) error
 	Receive() ([]Message, error)
-	Select() (int, error)
+	Select(tv *unix.Timeval) (int, error)
 }
 
 // Dial dials a connection to netlink, using the specified netlink family.
@@ -321,8 +322,8 @@ func (c *Conn) receive() ([]Message, error) {
 }
 
 // Select allow to check whether netlink messages are available
-func (c *Conn) Select() (int, error) {
-	return c.sock.Select()
+func (c *Conn) Select(tv *unix.Timeval) (int, error) {
+	return c.sock.Select(tv)
 }
 
 // A groupJoinLeaver is a Socket that supports joining and leaving

--- a/conn_linux.go
+++ b/conn_linux.go
@@ -35,7 +35,7 @@ type socket interface {
 	Close() error
 	FD() int
 	File() *os.File
-	Select() (int, error)
+	Select(tv *unix.Timeval) (int, error)
 	Getsockname() (unix.Sockaddr, error)
 	Recvmsg(p, oob []byte, flags int) (n int, oobn int, recvflags int, from unix.Sockaddr, err error)
 	Sendmsg(p, oob []byte, to unix.Sockaddr, flags int) error
@@ -186,8 +186,8 @@ func (c *conn) Receive() ([]Message, error) {
 }
 
 // Select allow to check whether netlink messages are available
-func (c *conn) Select() (int, error) {
-	return c.s.Select()
+func (c *conn) Select(tv *unix.Timeval) (int, error) {
+	return c.s.Select(tv)
 }
 
 // Close closes the connection.
@@ -523,13 +523,13 @@ func (s *sysSocket) FD() int { return int(s.fd.Fd()) }
 
 func (s *sysSocket) File() *os.File { return s.fd }
 
-func (s *sysSocket) Select() (int, error) {
+func (s *sysSocket) Select(tv *unix.Timeval) (int, error) {
 
 	var fdSet unix.FdSet
 	fdSet.Zero()
 	fdSet.Set(s.FD())
 
-	n, err := unix.Select(s.FD()+1, &fdSet, nil, nil, &unix.Timeval{})
+	n, err := unix.Select(s.FD()+1, &fdSet, nil, nil, tv)
 
 	return n, err
 }

--- a/conn_linux_integration_test.go
+++ b/conn_linux_integration_test.go
@@ -118,6 +118,29 @@ func TestIntegrationConnConcurrentManyConns(t *testing.T) {
 				panicf("unexpected number of reply messages: %d", l)
 			}
 		}
+
+		nsel, err := c.Select(&unix.Timeval{})
+		if err != nil {
+			t.Fatalf("failed to execute select: %v", err)
+		}
+
+		if nsel > 0 {
+			t.Fatalf("expected no messages")
+		}
+
+		_, err = c.Send(req)
+		if err != nil {
+			panicf("failed to send request: %v", err)
+		}
+
+		nsel, err = c.Select(&unix.Timeval{})
+		if err != nil {
+			t.Fatalf("failed to execute select: %v", err)
+		}
+
+		if nsel != 1 {
+			t.Fatalf("expected messages got none")
+		}
 	}
 
 	const (

--- a/conn_linux_test.go
+++ b/conn_linux_test.go
@@ -151,7 +151,7 @@ func TestLinuxConnReceive(t *testing.T) {
 	s.recvmsg.p = resb
 	s.recvmsg.from = from
 
-	n, err := c.Select()
+	n, err := c.Select(&unix.Timeval{})
 	if err != nil {
 		t.Fatalf("failed to execute: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestLinuxConnReceiveNoMessage(t *testing.T) {
 
 	c, _ := testLinuxConn(t, nil)
 
-	n, err := c.Select()
+	n, err := c.Select(&unix.Timeval{})
 	if err != nil {
 		t.Fatalf("failed to execute: %v", err)
 	}
@@ -656,7 +656,7 @@ func (s *testSocket) Getsockname() (unix.Sockaddr, error) {
 	return s.getsockname, s.getsocknameErr
 }
 
-func (s *testSocket) Select() (int, error) {
+func (s *testSocket) Select(tv *unix.Timeval) (int, error) {
 	if len(s.recvmsg.p) > 0 {
 		return 1, nil
 	}

--- a/conn_others.go
+++ b/conn_others.go
@@ -27,4 +27,4 @@ func (c *conn) Send(_ Message) error           { return errUnimplemented }
 func (c *conn) SendMessages(_ []Message) error { return errUnimplemented }
 func (c *conn) Receive() ([]Message, error)    { return nil, errUnimplemented }
 func (c *conn) Close() error                   { return errUnimplemented }
-func (c *conn) Select() (int, error)           { return -1, errUnimplemented }
+func (c *conn) Select(_ *unix.Timeval) (int, error) { return -1, errUnimplemented }

--- a/conn_others.go
+++ b/conn_others.go
@@ -5,6 +5,8 @@ package netlink
 import (
 	"fmt"
 	"runtime"
+
+	"golang.org/x/sys/unix"
 )
 
 // errUnimplemented is returned by all functions on platforms that
@@ -23,8 +25,8 @@ type conn struct{}
 func dial(_ int, _ *Config) (*conn, uint32, error) { return nil, 0, errUnimplemented }
 func newError(_ int) error                         { return errUnimplemented }
 
-func (c *conn) Send(_ Message) error           { return errUnimplemented }
-func (c *conn) SendMessages(_ []Message) error { return errUnimplemented }
-func (c *conn) Receive() ([]Message, error)    { return nil, errUnimplemented }
-func (c *conn) Close() error                   { return errUnimplemented }
+func (c *conn) Send(_ Message) error                { return errUnimplemented }
+func (c *conn) SendMessages(_ []Message) error      { return errUnimplemented }
+func (c *conn) Receive() ([]Message, error)         { return nil, errUnimplemented }
+func (c *conn) Close() error                        { return errUnimplemented }
 func (c *conn) Select(_ *unix.Timeval) (int, error) { return -1, errUnimplemented }

--- a/conn_others.go
+++ b/conn_others.go
@@ -27,3 +27,4 @@ func (c *conn) Send(_ Message) error           { return errUnimplemented }
 func (c *conn) SendMessages(_ []Message) error { return errUnimplemented }
 func (c *conn) Receive() ([]Message, error)    { return nil, errUnimplemented }
 func (c *conn) Close() error                   { return errUnimplemented }
+func (c *conn) Select() (int, error)           { return -1, errUnimplemented }

--- a/conn_others_test.go
+++ b/conn_others_test.go
@@ -37,4 +37,9 @@ func TestOthersConnUnimplemented(t *testing.T) {
 		t.Fatalf("unexpected error during c.Close:\n- want: %v\n-  got: %v",
 			want, got)
 	}
+
+	if _, got := c.Select(); want != got {
+		t.Fatalf("unexpected error during c.Select:\n- want: %v\n-  got: %v",
+			want, got)
+	}
 }

--- a/conn_others_test.go
+++ b/conn_others_test.go
@@ -2,7 +2,11 @@
 
 package netlink
 
-import "testing"
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
 
 func TestOthersConnUnimplemented(t *testing.T) {
 	c := &conn{}

--- a/conn_others_test.go
+++ b/conn_others_test.go
@@ -38,7 +38,7 @@ func TestOthersConnUnimplemented(t *testing.T) {
 			want, got)
 	}
 
-	if _, got := c.Select(); want != got {
+	if _, got := c.Select(&unix.Timeval{}); want != got {
 		t.Fatalf("unexpected error during c.Select:\n- want: %v\n-  got: %v",
 			want, got)
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/google/go-cmp v0.3.1
 	github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a
 	golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297
-	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456
+	golang.org/x/sys v0.0.0-20200103143344-a1369afcdac7
 )

--- a/go.sum
+++ b/go.sum
@@ -13,4 +13,6 @@ golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190411185658-b44545bcd369/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 h1:ng0gs1AKnRRuEMZoTLLlbOd+C17zUDepwGQBb/n+JVg=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200103143344-a1369afcdac7 h1:/W9OPMnnpmFXHYkcp2rQsbFUbRlRzfECQjmAFiOyHE8=
+golang.org/x/sys v0.0.0-20200103143344-a1369afcdac7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/nltest/nltest.go
+++ b/nltest/nltest.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mdlayher/netlink"
 	"github.com/mdlayher/netlink/nlenc"
+	"golang.org/x/sys/unix"
 )
 
 // PID is the netlink header PID value assigned by nltest.
@@ -204,7 +205,7 @@ func (c *socket) Receive() ([]netlink.Message, error) {
 	return msgs, err
 }
 
-func (c *socket) Select() (int, error) {
+func (c *socket) Select(tv *unix.Timeval) (int, error) {
 	msgs, _ := c.fn(nil)
 
 	if len(c.msgs) > 0 || len(msgs) > 0 {

--- a/nltest/nltest.go
+++ b/nltest/nltest.go
@@ -204,6 +204,16 @@ func (c *socket) Receive() ([]netlink.Message, error) {
 	return msgs, err
 }
 
+func (c *socket) Select() (int, error) {
+	msgs, _ := c.fn(nil)
+
+	if len(c.msgs) > 0 || len(msgs) > 0 {
+		return 1, nil
+	}
+
+	return 0, nil
+}
+
 func panicf(format string, a ...interface{}) {
 	panic(fmt.Sprintf(format, a...))
 }

--- a/nltest/nltest_test.go
+++ b/nltest/nltest_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/mdlayher/netlink"
 	"github.com/mdlayher/netlink/nltest"
+	"golang.org/x/sys/unix"
 )
 
 func TestConnSend(t *testing.T) {
@@ -54,7 +55,7 @@ func TestConnReceiveMulticast(t *testing.T) {
 	})
 	defer c.Close()
 
-	n, err := c.Select()
+	n, err := c.Select(&unix.Timeval{})
 	if err != nil {
 		t.Fatalf("failed to execute: %v", err)
 	}
@@ -80,7 +81,7 @@ func TestConnReceiveNoMessages(t *testing.T) {
 	})
 	defer c.Close()
 
-	n, err := c.Select()
+	n, err := c.Select(&unix.Timeval{})
 	if err != nil {
 		t.Fatalf("failed to execute: %v", err)
 	}

--- a/nltest/nltest_test.go
+++ b/nltest/nltest_test.go
@@ -54,6 +54,15 @@ func TestConnReceiveMulticast(t *testing.T) {
 	})
 	defer c.Close()
 
+	n, err := c.Select()
+	if err != nil {
+		t.Fatalf("failed to execute: %v", err)
+	}
+
+	if n != 1 {
+		t.Fatalf("expected messages")
+	}
+
 	got, err := c.Receive()
 	if err != nil {
 		t.Fatalf("failed to receive messages: %v", err)
@@ -70,6 +79,15 @@ func TestConnReceiveNoMessages(t *testing.T) {
 		return nil, io.EOF
 	})
 	defer c.Close()
+
+	n, err := c.Select()
+	if err != nil {
+		t.Fatalf("failed to execute: %v", err)
+	}
+
+	if n > 0 {
+		t.Fatalf("expected no messages")
+	}
 
 	msgs, err := c.Receive()
 	if err != nil {


### PR DESCRIPTION
Allow ``select`` to this kind of design:

```go
for i := 1; i > 0; i, _ = conn.Select(&unix.Timeval{}) {
	rmsg, err := conn.Receive()

	if err != nil {
		return fmt.Errorf("Receive: %w", err)
	}

	for _, msg := range rmsg {
		// do something
	}
}
```

I need this to trying reproduce behaviors of nftables which check with ``select`` before doing a ``recvmsg``, example of strace:

```bash
select(4, [3], NULL, NULL, {tv_sec=0, tv_usec=0}) = 1 (in [3], left {tv_sec=0, tv_usec=0})
recvmsg(......)
select(4, [3], NULL, NULL, {tv_sec=0, tv_usec=0}) = 1 (in [3], left {tv_sec=0, tv_usec=0})
recvmsg(......)
select(4, [3], NULL, NULL, {tv_sec=0, tv_usec=0}) = 0 (Timeout)
```