### PR TITLE
Use RTMGRP_* consts from x/sys/unix

### DIFF
--- a/conn_linux_integration_test.go
+++ b/conn_linux_integration_test.go
@@ -558,7 +558,7 @@ func rtnlDial(t *testing.T, netNS int) (*netlink.Conn, func()) {
 	})
 
 	c, err := netlink.Dial(unix.NETLINK_ROUTE, &netlink.Config{
-		Groups: 0x1, // RTMGRP_LINK
+		Groups: unix.RTMGRP_LINK,
 		NetNS:  netNS,
 	})
 	if err != nil {

--- a/conn_linux_test.go
+++ b/conn_linux_test.go
@@ -478,21 +478,21 @@ func TestLinuxConnConfig(t *testing.T) {
 		},
 		{
 			name:   "Config with Groups RTMGRP_IPV4_IFADDR",
-			config: &Config{Groups: 0x10},
-			groups: 0x10,
+			config: &Config{Groups: unix.RTMGRP_IPV4_IFADDR},
+			groups: unix.RTMGRP_IPV4_IFADDR,
 		},
 		{
 			name:   "Config with Groups RTMGRP_IPV4_IFADDR | RTMGRP_IPV4_ROUTE",
-			config: &Config{Groups: 0x10 | 0x40},
-			groups: 0x50,
+			config: &Config{Groups: unix.RTMGRP_IPV4_IFADDR | unix.RTMGRP_IPV4_ROUTE},
+			groups: unix.RTMGRP_IPV4_IFADDR | unix.RTMGRP_IPV4_ROUTE,
 		},
 		{
 			name: "Config with DisableNSLockThread and Groups RTMGRP_IPV4_IFADDR | RTMGRP_IPV4_ROUTE",
 			config: &Config{
-				Groups:              0x10 | 0x40,
+				Groups:              unix.RTMGRP_IPV4_IFADDR | unix.RTMGRP_IPV4_ROUTE,
 				DisableNSLockThread: true,
 			},
-			groups: 0x50,
+			groups: unix.RTMGRP_IPV4_IFADDR | unix.RTMGRP_IPV4_ROUTE,
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/google/go-cmp v0.4.0
 	github.com/jsimonetti/rtnetlink v0.0.0-20200117123717-f846d4f6c1f4
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
-	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
+	golang.org/x/sys v0.0.0-20200217220822-9197077df867
 )

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ golang.org/x/sys v0.0.0-20190411185658-b44545bcd369/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 h1:ng0gs1AKnRRuEMZoTLLlbOd+C17zUDepwGQBb/n+JVg=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
-golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867 h1:JoRuNIf+rpHl+VhScRQQvzbHed86tKkqwPMV34T8myw=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Bump golang.org/x/sys/unix to get the RTMGRP_* consts and use them.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>