### PR TITLE
Improve behaviour of SetReadBuffer / SetWriteBuffer

### DIFF
--- a/conn_linux.go
+++ b/conn_linux.go
@@ -291,7 +291,7 @@ func (c *conn) SetReadBuffer(bytes int) error {
 			bytes,
 		))
 	}
-	return nil
+	return err
 }
 
 // SetReadBuffer sets the size of the operating system's transmit buffer

--- a/conn_linux.go
+++ b/conn_linux.go
@@ -322,9 +322,9 @@ func (c *conn) GetReadBuffer() (int, error) {
 		unix.SO_RCVBUF,
 	)
 	if err != nil {
-		return value, os.NewSyscallError("getsockopt", err)
+		return 0, os.NewSyscallError("getsockopt", err)
 	}
-	return value, err
+	return value, nil
 }
 
 // GetWriteBuffer retrieves the size of the operating system's transmit buffer
@@ -335,9 +335,9 @@ func (c *conn) GetWriteBuffer() (int, error) {
 		unix.SO_SNDBUF,
 	)
 	if err != nil {
-		return value, os.NewSyscallError("getsockopt", err)
+		return 0, os.NewSyscallError("getsockopt", err)
 	}
-	return value, err
+	return value, nil
 }
 
 // linuxOption converts a ConnOption to its Linux value.
@@ -645,13 +645,15 @@ func (s *sysSocket) SetSockoptInt(level, opt, value int) error {
 }
 
 func (s *sysSocket) GetSockoptInt(level, opt int) (int, error) {
-	var value int
-	var err error
+	var (
+		value int
+		err   error
+	)
 	doErr := s.control(func(fd int) {
 		value, err = unix.GetsockoptInt(fd, level, opt)
 	})
 	if doErr != nil {
-		return value, doErr
+		return 0, doErr
 	}
 
 	return value, err

--- a/conn_linux_test.go
+++ b/conn_linux_test.go
@@ -679,6 +679,16 @@ func (s *testSocket) SetSockoptInt(level, opt, value int) error {
 	return nil
 }
 
+func (s *testSocket) GetSockoptInt(level, opt int) (int, error) {
+	for i := len(s.setSockopt)-1; i >= 0; i-- {
+		if s.setSockopt[i].level == level && s.setSockopt[i].opt == opt {
+			return s.setSockopt[i].value, nil
+		}
+	}
+
+	return 0, errors.New("getsockopt without preceding setsockopt")
+}
+
 func (s *testSocket) SetSockoptSockFprog(_, _ int, _ *unix.SockFprog) error {
 	panic("netlink: testSocket.SetSockoptSockFprog not currently implemented")
 }

--- a/conn_linux_test.go
+++ b/conn_linux_test.go
@@ -449,12 +449,12 @@ func TestLinuxConnSetBuffers(t *testing.T) {
 	want := []setSockopt{
 		{
 			level: unix.SOL_SOCKET,
-			opt:   unix.SO_RCVBUF,
+			opt:   unix.SO_RCVBUFFORCE,
 			value: n,
 		},
 		{
 			level: unix.SOL_SOCKET,
-			opt:   unix.SO_SNDBUF,
+			opt:   unix.SO_SNDBUFFORCE,
 			value: n,
 		},
 	}


### PR DESCRIPTION
(see issue #164 for a detailed explanation)

This PR allows users to use their privileges regarding buffer sizes: root and users with `CAP_NET_ADMIN` can ignore the system's limit on buffer sizes. Unprivileged users are not affected, there's a fallback. The testcase has been adjusted.

While I was working on this PR I noticed that the library has no method to read back the actual buffer size of the socket. I added these methods (`GetReadBuffer` and `GetWriteBuffer`) which are similar to their Write pendants.