### PR TITLE
Reduce thread locking behaviour to dial phase only

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -589,21 +589,6 @@ type Config struct {
 	// to 0.
 	NetNS int
 
-	// DisableNSLockThread disables package netlink's default goroutine thread
-	// locking behavior.
-	//
-	// By default, the library will lock the processing goroutine to its
-	// corresponding OS thread in order to enable communication over netlink to
-	// a different network namespace.
-	//
-	// If the caller already knows that the netlink socket is in the same
-	// namespace as the calling thread, this can introduce a performance
-	// impact. This option disables the OS thread locking behavior if
-	// performance considerations are of interest.
-	//
-	// If disabled, it is the responsibility of the caller to make sure that all
-	// threads are running in the correct namespace.
-	//
-	// When DisableNSLockThread is set, the caller cannot set the NetNS value.
+	// DisableNSLockThread is deprecated and has no effect.
 	DisableNSLockThread bool
 }

--- a/conn_linux_integration_test.go
+++ b/conn_linux_integration_test.go
@@ -92,9 +92,10 @@ func TestIntegrationConnConcurrentManyConns(t *testing.T) {
 	skipShort(t)
 
 	// Execute many concurrent operations on several netlink.Conns to ensure
-	// messages cannot be sent to the wrong connection.
+	// the kernel is sending and receiving netlink messages to/from the correct
+	// file descriptor.
 	//
-	// See newLockedNetNSGoroutine internally.
+	// See: http://lists.infradead.org/pipermail/libnl/2017-February/002293.html.
 	execN := func(n int) {
 		c, err := netlink.Dial(unix.NETLINK_GENERIC, nil)
 		if err != nil {

--- a/conn_linux_test.go
+++ b/conn_linux_test.go
@@ -508,66 +508,6 @@ func TestLinuxConnConfig(t *testing.T) {
 	}
 }
 
-func Test_newLockedNetNSGoroutineNetNSDisabled(t *testing.T) {
-	tests := []struct {
-		name       string
-		ns         int
-		ok         bool
-		lockThread bool
-	}{
-		{
-			// Network namespaces are disabled but none is set: this should
-			// succeed.
-			name:       "not set",
-			ok:         true,
-			lockThread: true,
-		},
-		{
-			// Network namespaces are disabled but one is set explicitly:
-			// this should fail.
-			name:       "set",
-			ns:         1,
-			lockThread: true,
-		},
-		{
-			// thread locking is disabled but an ns is provided.
-			// this should fail.
-			name:       "disable lock thread with ns defined",
-			ns:         1,
-			lockThread: false,
-		},
-		{
-			// thread locking is disabled but an ns is not provided.
-			// this should succeed.
-			name:       "disable lock thread without ns defined",
-			lockThread: false,
-			ok:         true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g, err := newLockedNetNSGoroutine(tt.ns, func() (*netNS, error) {
-				// Network namespaces should be disabled due to a non-existent
-				// file.
-				return fileNetNS("/netlinktestdoesnotexist")
-			}, tt.lockThread)
-			if err != nil {
-				if tt.ok {
-					t.Fatalf("failed to create goroutine: %v", err)
-				}
-
-				return
-			}
-			defer g.stop()
-
-			if !tt.ok {
-				t.Fatal("expected an error, but none occurred")
-			}
-		})
-	}
-}
-
 func testLinuxConn(t *testing.T, config *Config) (*conn, *testSocket) {
 	s := &testSocket{}
 	c, _, err := bind(s, config)
@@ -680,7 +620,7 @@ func (s *testSocket) SetSockoptInt(level, opt, value int) error {
 }
 
 func (s *testSocket) GetSockoptInt(level, opt int) (int, error) {
-	for i := len(s.setSockopt)-1; i >= 0; i-- {
+	for i := len(s.setSockopt) - 1; i >= 0; i-- {
 		if s.setSockopt[i].level == level && s.setSockopt[i].opt == opt {
 			return s.setSockopt[i].value, nil
 		}

--- a/netns_linux_test.go
+++ b/netns_linux_test.go
@@ -1,0 +1,46 @@
+//+build linux
+
+package netlink
+
+import (
+	"testing"
+)
+
+func TestNetNSDisabled(t *testing.T) {
+
+	// Attempt to open a non-existent file as a netns descriptor.
+	netns, err := fileNetNS("/netlinktestdoesnotexist")
+	if err != nil {
+		t.Fatal("unexpected error opening dummy netns file", err)
+	}
+	if !netns.disabled {
+		t.Fatal("expected netNS to have disabled flag set")
+	}
+
+	// do skips invoking its argument when netns.disabled is set.
+	_ = netns.do(
+		func() error {
+			t.Fatal("this function should never execute when netns are disabled")
+			return nil
+		})
+
+	if netns.FD() > 0 {
+		t.Fatal("expected invalid netns fd when netns are disabled")
+	}
+}
+
+func TestThreadNetNS(t *testing.T) {
+
+	netns, err := threadNetNS()
+	if err != nil {
+		t.Fatal("error getting thread's network namespace:", err)
+	}
+
+	if netns.FD() < 0 {
+		t.Fatal("expected valid netns fd (> 0)")
+	}
+
+	if err := netns.Close(); err != nil {
+		t.Fatal("error closing netns handle:", err)
+	}
+}


### PR DESCRIPTION
:wave: Back again with another controversial change. :smile: This aims to eliminate the bottleneck described in https://github.com/mdlayher/netlink/issues/154. This is the approach I described in https://github.com/mdlayher/netlink/issues/154#issuecomment-578045314. With the goal of dropping support for Go 1.11 and lower, this might be a good time to revisit.

To Do:
- [ ] Reintroduce a test for machines with network namespaces disabled, since `newLockedNetNSGoroutine` was removed

---

There are 2 elements at play here:
- The message misrouting discussed in http://lists.infradead.org/pipermail/libnl/2017-February/002293.html
  With this change, I'd like to start spelunking older versions of the kernel and the Go runtime for this bug. @mdlayher are you positive the `TestIntegrationConnConcurrent*` family of tests is able to reproduce this? Can you remember which Go and kernel version you were using at the time when this was written?

- Socket creation inside network namespaces
  As far as namespaces are concerned, OS threads only briefly need to enter a netns to create the netlink socket and can safely be returned to the host namespace once the socket fd has been allocated. We don't need to lock OS threads permanently to operate in multiple namespaces.

---

Some feedback please. :pray:  Still looking for a way to inject a mock `func getNS` somewhere into the `dial()` code path to emulate systems with network namespaces disabled.