### PR TITLE
netlink: add PID for netlink dial config

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -558,4 +558,8 @@ type Config struct {
 
 	// DisableNSLockThread is deprecated and has no effect.
 	DisableNSLockThread bool
+
+	// the unicast address of netlink socket. If set it to 0,
+	// the kernel takes care of assigning it.
+	Pid uint32
 }

--- a/conn_linux.go
+++ b/conn_linux.go
@@ -74,6 +74,7 @@ func newConn(s *socket.Conn, config *Config) (*conn, uint32, error) {
 	addr := &unix.SockaddrNetlink{
 		Family: unix.AF_NETLINK,
 		Groups: config.Groups,
+		Pid:    config.Pid,
 	}
 
 	// Socket must be closed in the event of any system call errors, to avoid

--- a/message.go
+++ b/message.go
@@ -188,7 +188,7 @@ type Header struct {
 	// The sequence number of a Message.
 	Sequence uint32
 
-	// The process ID of the sending process.
+	// Sender port ID, usually the process ID of the sending process.
 	PID uint32
 }
 


### PR DESCRIPTION
If you want to receive unicast message from kernel, you need to specify the PID of SockaddrNetlink when bind.
For example, you have a kernel module and you want to commuinicate with your userspace program.