### PR TITLE
netlink: add //go:build lines

### DIFF
--- a/conn_linux.go
+++ b/conn_linux.go
@@ -1,4 +1,5 @@
-//+build linux
+//go:build linux
+// +build linux
 
 package netlink
 

--- a/conn_linux_error_test.go
+++ b/conn_linux_error_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netlink_test

--- a/conn_linux_integration_test.go
+++ b/conn_linux_integration_test.go
@@ -1,4 +1,5 @@
-//+build linux
+//go:build linux
+// +build linux
 
 package netlink_test
 

--- a/conn_others.go
+++ b/conn_others.go
@@ -1,4 +1,5 @@
-//+build !linux
+//go:build !linux
+// +build !linux
 
 package netlink
 

--- a/conn_others_test.go
+++ b/conn_others_test.go
@@ -1,4 +1,5 @@
-//+build !linux
+//go:build !linux
+// +build !linux
 
 package netlink
 

--- a/export_linux_test.go
+++ b/export_linux_test.go
@@ -1,4 +1,5 @@
-//+build go1.12,linux
+//go:build go1.12 && linux
+// +build go1.12,linux
 
 package netlink
 

--- a/fuzz.go
+++ b/fuzz.go
@@ -1,4 +1,5 @@
-//+build gofuzz
+//go:build gofuzz
+// +build gofuzz
 
 package netlink
 

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,4 +1,5 @@
-//+build gofuzz
+//go:build gofuzz
+// +build gofuzz
 
 package netlink
 

--- a/message_linux_test.go
+++ b/message_linux_test.go
@@ -1,4 +1,5 @@
-//+build linux
+//go:build linux
+// +build linux
 
 package netlink
 

--- a/netlink_linux_gteq_1.13_test.go
+++ b/netlink_linux_gteq_1.13_test.go
@@ -1,3 +1,4 @@
+//go:build linux && go1.13
 // +build linux,go1.13
 
 package netlink_test

--- a/netns_linux.go
+++ b/netns_linux.go
@@ -1,4 +1,5 @@
-//+build linux
+//go:build linux
+// +build linux
 
 package netlink
 

--- a/netns_linux_test.go
+++ b/netns_linux_test.go
@@ -1,4 +1,5 @@
-//+build linux
+//go:build linux
+// +build linux
 
 package netlink
 

--- a/nltest/errors_others.go
+++ b/nltest/errors_others.go
@@ -1,4 +1,5 @@
-//+build plan9 windows
+//go:build plan9 || windows
+// +build plan9 windows
 
 package nltest
 

--- a/nltest/errors_unix.go
+++ b/nltest/errors_unix.go
@@ -1,4 +1,5 @@
-//+build !plan9,!windows
+//go:build !plan9 && !windows
+// +build !plan9,!windows
 
 package nltest
 

--- a/nltest/nltest_linux_gteq_1.13_test.go
+++ b/nltest/nltest_linux_gteq_1.13_test.go
@@ -1,4 +1,5 @@
-//+build linux,go1.13
+//go:build linux && go1.13
+// +build linux,go1.13
 
 package nltest_test
 


### PR DESCRIPTION
Starting with Go 1.17, //go:build lines are preferred over // +build
lines, see https://golang.org/doc/go1.17#build-lines and
https://golang.org/design/draft-gobuild for details.

This change was generated by running Go 1.17 go fmt ./... which
automatically adds //go:build lines based on the existing // +build
lines.