### PR TITLE
tests: Fix integer overflow on 32-bit architectures

### DIFF
--- a/conn_linux_integration_test.go
+++ b/conn_linux_integration_test.go
@@ -6,7 +6,6 @@ package netlink_test
 import (
 	"errors"
 	"fmt"
-	"math"
 	"math/rand"
 	"net"
 	"os"
@@ -601,7 +600,7 @@ func TestIntegrationConnExplicitPID(t *testing.T) {
 	// PID will be used in messages that are sent to and received from the
 	// kernel.
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-	pid := uint32(rng.Intn(math.MaxUint32))
+	pid := rng.Uint32()
 
 	c, err := netlink.Dial(unix.NETLINK_GENERIC, &netlink.Config{PID: pid})
 	if err != nil {


### PR DESCRIPTION
On 32-bit architectures like armhf and i386, `math.MaxUint32` is bigger than the maximum value the signed 32-bit `int` can take. This causes the tests to fail to build:

```
conn_linux_integration_test.go:604:24: constant 4294967295 overflows int
FAIL	github.com/mdlayher/netlink [build failed]
```

So use `(*Rand) Uint32` instead which returns a pseudo-random 32-bit value as a `uint32`.