### PR TITLE
feat: Handle OobData

### DIFF
--- a/align.go
+++ b/align.go
@@ -35,3 +35,8 @@ const sizeofAttribute = 4
 
 // #define NLA_HDRLEN              ((int) NLA_ALIGN(sizeof(struct nlattr)))
 var nlaHeaderLen = nlaAlign(sizeofAttribute)
+
+// #define CMSG_ALIGN(len) ( ((len)+sizeof(long)-1) & ~(sizeof(long)-1) )
+func cmsgAlign(len int) int {
+	return ((len) + int(unsafe.Sizeof(int(0))-1)) & ^(int(unsafe.Sizeof(int(0)) - 1))
+}

--- a/conn.go
+++ b/conn.go
@@ -590,4 +590,10 @@ type Config struct {
 	// When possible, setting Strict to true is recommended for applications
 	// running on modern Linux kernels.
 	Strict bool
+
+	// EnableControlMessages enables the use of control messages for
+	// netlink. This option is intended for advanced use cases where the
+	// caller needs to receive control messages that contain ancillary data.
+	// For example, when using options like `ListenAllNSID`.
+	EnableControlMessages bool
 }

--- a/message.go
+++ b/message.go
@@ -194,12 +194,14 @@ type Header struct {
 
 // A Message is a netlink message.  It contains a Header and an arbitrary
 // byte payload, which may be decoded using information from the Header.
+// It may also contain out-of-band data, which was sent along with the message.
 //
 // Data is often populated with netlink attributes. For easy encoding and
 // decoding of attributes, see the AttributeDecoder and AttributeEncoder types.
 type Message struct {
-	Header Header
-	Data   []byte
+	Header  Header
+	Data    []byte
+	OobData []byte
 }
 
 // MarshalBinary marshals a Message into a byte slice.


### PR DESCRIPTION
Adds OobData []byte to the Message struct.
During the Recieve() function, this field is populated with the raw bytes of any control messages recieved from the recvmsg call.

An example of how to process the OobData field has been included.