### PR TITLE
Add Sequence number to OpError type

### DIFF
--- a/conn_linux_error_test.go
+++ b/conn_linux_error_test.go
@@ -37,15 +37,16 @@ func TestConnReceiveErrorLinux(t *testing.T) {
 				Header: netlink.Header{
 					Length:   20,
 					Type:     netlink.Error,
-					Sequence: 1,
+					Sequence: 1234,
 					PID:      1,
 				},
 				// -2, little endian (ENOENT)
 				Data: []byte{0xfe, 0xff, 0xff, 0xff},
 			}},
 			want: &netlink.OpError{
-				Op:  "receive",
-				Err: unix.ENOENT,
+				Op:       "receive",
+				Err:      unix.ENOENT,
+				Sequence: 1234,
 			},
 		},
 		{

--- a/errors.go
+++ b/errors.go
@@ -63,6 +63,11 @@ type OpError struct {
 	// library.
 	Err error
 
+	// Sequence contains the sequence number of the netlink message which caused
+	// this error. This will only be valid if Op is "receive", otherwise this
+	// field will be set to zero.
+	Sequence uint32
+
 	// Message and Offset contain additional error information provided by the
 	// kernel when the ExtendedAcknowledge option is set on a Conn and the
 	// kernel indicates the AcknowledgeTLVs flag in a response. If this option


### PR DESCRIPTION
I am trying to write an asynchronous wrapper around a `netlink.Conn` so that a single connection can be shared amongst many goroutines and it's been working pretty good so far, except when it comes to handling errors. The problem arises because the `OpError` type doesn't include anything that can be used to match up with the request that generated the error. It would be handy if we could include the `Sequence` field from the netlink header in the `OpError` to facilitate such a match.