### PR TITLE
Fix skipping of specific tests on big-endian hosts

### DIFF
--- a/conn_linux_error_test.go
+++ b/conn_linux_error_test.go
@@ -4,13 +4,13 @@
 package netlink_test
 
 import (
-	"encoding/binary"
 	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/mdlayher/netlink"
 	"github.com/mdlayher/netlink/nltest"
+	"golang.org/x/sys/cpu"
 	"golang.org/x/sys/unix"
 )
 
@@ -115,7 +115,7 @@ func TestConnReceiveErrorLinux(t *testing.T) {
 }
 
 func skipBigEndian(t *testing.T) {
-	if binary.ByteOrder(binary.NativeEndian) == binary.BigEndian {
+	if cpu.IsBigEndian {
 		t.Skip("skipping test on big-endian system")
 	}
 }

--- a/message_test.go
+++ b/message_test.go
@@ -2,10 +2,11 @@ package netlink
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
 	"reflect"
 	"testing"
+
+	"golang.org/x/sys/cpu"
 )
 
 func TestHeaderFlagsString(t *testing.T) {
@@ -474,7 +475,7 @@ func TestValidate(t *testing.T) {
 }
 
 func skipBigEndian(t *testing.T) {
-	if binary.ByteOrder(binary.NativeEndian) == binary.BigEndian {
+	if cpu.IsBigEndian {
 		t.Skip("skipping test on big-endian system")
 	}
 }

--- a/nlenc/int_test.go
+++ b/nlenc/int_test.go
@@ -2,9 +2,10 @@ package nlenc
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"testing"
+
+	"golang.org/x/sys/cpu"
 )
 
 func TestUintPanic(t *testing.T) {
@@ -456,7 +457,7 @@ func TestInt32(t *testing.T) {
 }
 
 func skipBigEndian(t *testing.T) {
-	if NativeEndian() == binary.BigEndian {
+	if cpu.IsBigEndian {
 		t.Skip("skipping test on big-endian system")
 	}
 }

--- a/nltest/nltest_test.go
+++ b/nltest/nltest_test.go
@@ -2,7 +2,6 @@ package nltest_test
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
 	"io"
 	"reflect"
@@ -11,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/mdlayher/netlink"
 	"github.com/mdlayher/netlink/nltest"
+	"golang.org/x/sys/cpu"
 )
 
 func TestConnSend(t *testing.T) {
@@ -537,7 +537,7 @@ var noop = func(req []netlink.Message) ([]netlink.Message, error) {
 }
 
 func skipBigEndian(t *testing.T) {
-	if binary.ByteOrder(binary.NativeEndian) == binary.BigEndian {
+	if cpu.IsBigEndian {
 		t.Skip("skipping test on big-endian system")
 	}
 }


### PR DESCRIPTION
`binary.NativeEndian` cannot be compared with `binary.LittleEndian` or `binary.BigEndian`. See https://github.com/golang/go/issues/63611

Fixes: #227