### PR TITLE
Add bigendian test fixtures for nlenc package

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -34,8 +34,8 @@ func (a *Attribute) marshal(b []byte) (int, error) {
 		return 0, errInvalidAttribute
 	}
 
-	nlenc.PutUint16(b[0:2], a.Length)
-	nlenc.PutUint16(b[2:4], a.Type)
+	binary.NativeEndian.PutUint16(b[0:], a.Length)
+	binary.NativeEndian.PutUint16(b[2:], a.Type)
 	n := copy(b[nlaHeaderLen:], a.Data)
 
 	return nlaHeaderLen + nlaAlign(n), nil
@@ -47,8 +47,8 @@ func (a *Attribute) unmarshal(b []byte) error {
 		return errInvalidAttribute
 	}
 
-	a.Length = nlenc.Uint16(b[0:2])
-	a.Type = nlenc.Uint16(b[2:4])
+	a.Length = binary.NativeEndian.Uint16(b[0:])
+	a.Type = binary.NativeEndian.Uint16(b[2:])
 
 	if int(a.Length) > len(b) {
 		return errInvalidAttribute
@@ -243,7 +243,7 @@ func (ad *AttributeDecoder) available() (int, error) {
 		}
 
 		// Extract the length of the attribute.
-		l := int(nlenc.Uint16(ad.b[i : i+2]))
+		l := int(binary.NativeEndian.Uint16(ad.b[i:]))
 
 		// Ignore zero-length attributes.
 		if l != 0 {

--- a/conn_linux_integration_test.go
+++ b/conn_linux_integration_test.go
@@ -3,6 +3,7 @@
 package netlink_test
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -17,7 +18,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/mdlayher/netlink"
-	"github.com/mdlayher/netlink/nlenc"
 	"golang.org/x/net/bpf"
 	"golang.org/x/sys/unix"
 )
@@ -54,7 +54,7 @@ func TestIntegrationConn(t *testing.T) {
 
 	m := msgs[0]
 
-	if want, got := 0, int(nlenc.Uint32(m.Data[0:4])); want != got {
+	if want, got := 0, int(binary.NativeEndian.Uint32(m.Data[0:])); want != got {
 		t.Fatalf("unexpected error code:\n- want: %v\n-  got: %v", want, got)
 	}
 

--- a/debug_linux.go
+++ b/debug_linux.go
@@ -3,6 +3,7 @@
 package netlink
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 	"log"
@@ -12,7 +13,6 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/mdlayher/netlink/nlenc"
 	"golang.org/x/sys/unix"
 )
 
@@ -102,7 +102,7 @@ func nlmsgFprintf(fd io.Writer, m Message, colorize bool) {
 		return
 	}
 
-	c := nlenc.Int32(m.Data[:endErrno])
+	c := int32(binary.NativeEndian.Uint32(m.Data[:endErrno]))
 	if c != 0 {
 		b := m.Data[0:4]
 		fmt.Fprintf(fd, "| %.2x %.2x %.2x %.2x  |\t",
@@ -139,9 +139,9 @@ func nlmsgFprintf(fd io.Writer, m Message, colorize bool) {
 			break
 		}
 		// Extract the length of the attribute.
-		l := int(nlenc.Uint16(data[i : i+2]))
+		l := int(binary.NativeEndian.Uint16(data[i:]))
 		// extract the type
-		t := nlenc.Uint16(data[i+2 : i+4])
+		t := binary.NativeEndian.Uint16(data[i+2:])
 		// print attribute header
 		if colorize {
 			fmt.Fprintf(fd, "|\033[1;31m%05d|\033[1;32m%s%s|\033[1;34m%05d\033[0m|\t",

--- a/message.go
+++ b/message.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"iter"
 	"unsafe"
-
-	"github.com/mdlayher/netlink/nlenc"
 )
 
 // Flags which may apply to netlink attribute types when communicating with
@@ -213,11 +211,11 @@ func (m Message) MarshalBinary() ([]byte, error) {
 
 	b := make([]byte, ml)
 
-	nlenc.PutUint32(b[0:4], m.Header.Length)
-	nlenc.PutUint16(b[4:6], uint16(m.Header.Type))
-	nlenc.PutUint16(b[6:8], uint16(m.Header.Flags))
-	nlenc.PutUint32(b[8:12], m.Header.Sequence)
-	nlenc.PutUint32(b[12:16], m.Header.PID)
+	binary.NativeEndian.PutUint32(b[0:], m.Header.Length)
+	binary.NativeEndian.PutUint16(b[4:], uint16(m.Header.Type))
+	binary.NativeEndian.PutUint16(b[6:], uint16(m.Header.Flags))
+	binary.NativeEndian.PutUint32(b[8:], m.Header.Sequence)
+	binary.NativeEndian.PutUint32(b[12:], m.Header.PID)
 	copy(b[16:], m.Data)
 
 	return b, nil
@@ -233,15 +231,15 @@ func (m *Message) UnmarshalBinary(b []byte) error {
 	}
 
 	// Don't allow misleading length
-	m.Header.Length = nlenc.Uint32(b[0:4])
+	m.Header.Length = binary.NativeEndian.Uint32(b[0:])
 	if int(m.Header.Length) != len(b) {
 		return errShortMessage
 	}
 
-	m.Header.Type = HeaderType(nlenc.Uint16(b[4:6]))
-	m.Header.Flags = HeaderFlags(nlenc.Uint16(b[6:8]))
-	m.Header.Sequence = nlenc.Uint32(b[8:12])
-	m.Header.PID = nlenc.Uint32(b[12:16])
+	m.Header.Type = HeaderType(binary.NativeEndian.Uint16(b[4:]))
+	m.Header.Flags = HeaderFlags(binary.NativeEndian.Uint16(b[6:]))
+	m.Header.Sequence = binary.NativeEndian.Uint32(b[8:])
+	m.Header.PID = binary.NativeEndian.Uint32(b[12:])
 	m.Data = b[16:]
 
 	return nil
@@ -284,7 +282,7 @@ func checkMessage(m Message) error {
 		return newOpError("receive", errShortErrorMessage)
 	}
 
-	c := nlenc.Int32(m.Data[:endErrno])
+	c := int32(binary.NativeEndian.Uint32(m.Data[:endErrno]))
 	if c == 0 {
 		// 0 indicates no error.
 		return nil
@@ -359,7 +357,7 @@ func checkMessage(m Message) error {
 func parseMessagesIter(b []byte) iter.Seq2[Message, error] {
 	return func(yield func(Message, error) bool) {
 		for len(b) >= nlmsgHeaderLen {
-			length := binary.NativeEndian.Uint32(b[0:4])
+			length := binary.NativeEndian.Uint32(b[0:])
 			if int(length) < nlmsgHeaderLen {
 				yield(Message{}, errIncorrectMessageLength)
 				return

--- a/nlenc/doc.go
+++ b/nlenc/doc.go
@@ -7,6 +7,8 @@ import (
 )
 
 // NativeEndian returns the native byte order of this system.
+//
+// Deprecated: Use [binary.NativeEndian] instead.
 func NativeEndian() binary.ByteOrder {
 	// TODO(mdlayher): consider deprecating and removing this function for v2.
 	return binary.NativeEndian

--- a/nlenc/int.go
+++ b/nlenc/int.go
@@ -7,6 +7,8 @@ import (
 
 // PutUint8 encodes a uint8 into b.
 // If b is not exactly 1 byte in length, PutUint8 will panic.
+//
+// Deprecated: Use inline "b[n] = v" instead.
 func PutUint8(b []byte, v uint8) {
 	if l := len(b); l != 1 {
 		panic(fmt.Sprintf("PutUint8: unexpected byte slice length: %d", l))
@@ -65,6 +67,8 @@ func PutInt32(b []byte, v int32) {
 
 // Uint8 decodes a uint8 from b.
 // If b is not exactly 1 byte in length, Uint8 will panic.
+//
+// Deprecated: Use inline "b[n]" instead.
 func Uint8(b []byte) uint8 {
 	if l := len(b); l != 1 {
 		panic(fmt.Sprintf("Uint8: unexpected byte slice length: %d", l))
@@ -123,6 +127,8 @@ func Int32(b []byte) int32 {
 
 // Uint8Bytes encodes a uint8 into a newly-allocated byte slice. It is a
 // shortcut for allocating a new byte slice and filling it using PutUint8.
+//
+// Deprecated: Use inline "[]byte{v}" instead.
 func Uint8Bytes(v uint8) []byte {
 	return []byte{v}
 }

--- a/nlenc/int.go
+++ b/nlenc/int.go
@@ -1,8 +1,8 @@
 package nlenc
 
 import (
+	"encoding/binary"
 	"fmt"
-	"unsafe"
 )
 
 // PutUint8 encodes a uint8 into b.
@@ -17,42 +17,50 @@ func PutUint8(b []byte, v uint8) {
 
 // PutUint16 encodes a uint16 into b using the host machine's native endianness.
 // If b is not exactly 2 bytes in length, PutUint16 will panic.
+//
+// Deprecated: Use [binary.NativeEndian.PutUint16] instead.
 func PutUint16(b []byte, v uint16) {
 	if l := len(b); l != 2 {
 		panic(fmt.Sprintf("PutUint16: unexpected byte slice length: %d", l))
 	}
 
-	*(*uint16)(unsafe.Pointer(&b[0])) = v
+	binary.NativeEndian.PutUint16(b, v)
 }
 
 // PutUint32 encodes a uint32 into b using the host machine's native endianness.
 // If b is not exactly 4 bytes in length, PutUint32 will panic.
+//
+// Deprecated: Use [binary.NativeEndian.PutUint32] instead.
 func PutUint32(b []byte, v uint32) {
 	if l := len(b); l != 4 {
 		panic(fmt.Sprintf("PutUint32: unexpected byte slice length: %d", l))
 	}
 
-	*(*uint32)(unsafe.Pointer(&b[0])) = v
+	binary.NativeEndian.PutUint32(b, v)
 }
 
 // PutUint64 encodes a uint64 into b using the host machine's native endianness.
 // If b is not exactly 8 bytes in length, PutUint64 will panic.
+//
+// Deprecated: Use [binary.NativeEndian.PutUint64] instead.
 func PutUint64(b []byte, v uint64) {
 	if l := len(b); l != 8 {
 		panic(fmt.Sprintf("PutUint64: unexpected byte slice length: %d", l))
 	}
 
-	*(*uint64)(unsafe.Pointer(&b[0])) = v
+	binary.NativeEndian.PutUint64(b, v)
 }
 
 // PutInt32 encodes a int32 into b using the host machine's native endianness.
 // If b is not exactly 4 bytes in length, PutInt32 will panic.
+//
+// Deprecated: Use [binary.NativeEndian.PutUint32] instead (with a typecast).
 func PutInt32(b []byte, v int32) {
 	if l := len(b); l != 4 {
 		panic(fmt.Sprintf("PutInt32: unexpected byte slice length: %d", l))
 	}
 
-	*(*int32)(unsafe.Pointer(&b[0])) = v
+	binary.NativeEndian.PutUint32(b, uint32(v))
 }
 
 // Uint8 decodes a uint8 from b.
@@ -67,50 +75,56 @@ func Uint8(b []byte) uint8 {
 
 // Uint16 decodes a uint16 from b using the host machine's native endianness.
 // If b is not exactly 2 bytes in length, Uint16 will panic.
+//
+// Deprecated: Use [binary.NativeEndian.Uint16] instead.
 func Uint16(b []byte) uint16 {
 	if l := len(b); l != 2 {
 		panic(fmt.Sprintf("Uint16: unexpected byte slice length: %d", l))
 	}
 
-	return *(*uint16)(unsafe.Pointer(&b[0]))
+	return binary.NativeEndian.Uint16(b)
 }
 
 // Uint32 decodes a uint32 from b using the host machine's native endianness.
 // If b is not exactly 4 bytes in length, Uint32 will panic.
+//
+// Deprecated: Use [binary.NativeEndian.Uint32] instead.
 func Uint32(b []byte) uint32 {
 	if l := len(b); l != 4 {
 		panic(fmt.Sprintf("Uint32: unexpected byte slice length: %d", l))
 	}
 
-	return *(*uint32)(unsafe.Pointer(&b[0]))
+	return binary.NativeEndian.Uint32(b)
 }
 
 // Uint64 decodes a uint64 from b using the host machine's native endianness.
 // If b is not exactly 8 bytes in length, Uint64 will panic.
+//
+// Deprecated: Use [binary.NativeEndian.Uint64] instead.
 func Uint64(b []byte) uint64 {
 	if l := len(b); l != 8 {
 		panic(fmt.Sprintf("Uint64: unexpected byte slice length: %d", l))
 	}
 
-	return *(*uint64)(unsafe.Pointer(&b[0]))
+	return binary.NativeEndian.Uint64(b)
 }
 
 // Int32 decodes an int32 from b using the host machine's native endianness.
 // If b is not exactly 4 bytes in length, Int32 will panic.
+//
+// Deprecated: Use [binary.NativeEndian.Uint32] instead (with a typecast).
 func Int32(b []byte) int32 {
 	if l := len(b); l != 4 {
 		panic(fmt.Sprintf("Int32: unexpected byte slice length: %d", l))
 	}
 
-	return *(*int32)(unsafe.Pointer(&b[0]))
+	return int32(binary.NativeEndian.Uint32(b))
 }
 
 // Uint8Bytes encodes a uint8 into a newly-allocated byte slice. It is a
 // shortcut for allocating a new byte slice and filling it using PutUint8.
 func Uint8Bytes(v uint8) []byte {
-	b := make([]byte, 1)
-	PutUint8(b, v)
-	return b
+	return []byte{v}
 }
 
 // Uint16Bytes encodes a uint16 into a newly-allocated byte slice using the
@@ -118,7 +132,7 @@ func Uint8Bytes(v uint8) []byte {
 // byte slice and filling it using PutUint16.
 func Uint16Bytes(v uint16) []byte {
 	b := make([]byte, 2)
-	PutUint16(b, v)
+	binary.NativeEndian.PutUint16(b, v)
 	return b
 }
 
@@ -127,7 +141,7 @@ func Uint16Bytes(v uint16) []byte {
 // byte slice and filling it using PutUint32.
 func Uint32Bytes(v uint32) []byte {
 	b := make([]byte, 4)
-	PutUint32(b, v)
+	binary.NativeEndian.PutUint32(b, v)
 	return b
 }
 
@@ -136,7 +150,7 @@ func Uint32Bytes(v uint32) []byte {
 // byte slice and filling it using PutUint64.
 func Uint64Bytes(v uint64) []byte {
 	b := make([]byte, 8)
-	PutUint64(b, v)
+	binary.NativeEndian.PutUint64(b, v)
 	return b
 }
 
@@ -145,6 +159,6 @@ func Uint64Bytes(v uint64) []byte {
 // byte slice and filling it using PutInt32.
 func Int32Bytes(v int32) []byte {
 	b := make([]byte, 4)
-	PutInt32(b, v)
+	binary.NativeEndian.PutUint32(b, uint32(v))
 	return b
 }

--- a/nlenc/int_test.go
+++ b/nlenc/int_test.go
@@ -213,26 +213,29 @@ func TestUint8(t *testing.T) {
 }
 
 func TestUint16(t *testing.T) {
-	skipBigEndian(t)
 	tests := []struct {
-		v uint16
-		b []byte
+		v      uint16
+		le, be []byte
 	}{
 		{
-			v: 0x1,
-			b: []byte{0x01, 0x00},
+			v:  0x1,
+			le: []byte{0x01, 0x00},
+			be: []byte{0x00, 0x01},
 		},
 		{
-			v: 0x0102,
-			b: []byte{0x02, 0x01},
+			v:  0x0102,
+			le: []byte{0x02, 0x01},
+			be: []byte{0x01, 0x02},
 		},
 		{
-			v: 0x1234,
-			b: []byte{0x34, 0x12},
+			v:  0x1234,
+			le: []byte{0x34, 0x12},
+			be: []byte{0x12, 0x34},
 		},
 		{
-			v: 0xffff,
-			b: []byte{0xff, 0xff},
+			v:  0xffff,
+			le: []byte{0xff, 0xff},
+			be: []byte{0xff, 0xff},
 		},
 	}
 
@@ -241,21 +244,24 @@ func TestUint16(t *testing.T) {
 			b := make([]byte, 2)
 			PutUint16(b, tt.v)
 
-			if want, got := tt.b, b; !bytes.Equal(want, got) {
+			var want []byte
+			if cpu.IsBigEndian {
+				want = tt.be
+			} else {
+				want = tt.le
+			}
+
+			if got := b; !bytes.Equal(want, got) {
 				t.Fatalf("unexpected bytes:\n- want: [%# x]\n-  got: [%# x]",
 					want, got)
 			}
 
-			v := Uint16(b)
-
-			if want, got := tt.v, v; want != got {
+			if want, got := tt.v, Uint16(b); want != got {
 				t.Fatalf("unexpected integer:\n- want: 0x%04x\n-  got: 0x%04x",
 					want, got)
 			}
 
-			b = Uint16Bytes(tt.v)
-
-			if want, got := tt.b, b; !bytes.Equal(want, got) {
+			if got := Uint16Bytes(tt.v); !bytes.Equal(want, got) {
 				t.Fatalf("unexpected bytes:\n- want: [%# x]\n-  got: [%# x]",
 					want, got)
 			}
@@ -264,34 +270,39 @@ func TestUint16(t *testing.T) {
 }
 
 func TestUint32(t *testing.T) {
-	skipBigEndian(t)
 	tests := []struct {
-		v uint32
-		b []byte
+		v      uint32
+		le, be []byte
 	}{
 		{
-			v: 0x1,
-			b: []byte{0x01, 0x00, 0x00, 0x00},
+			v:  0x1,
+			le: []byte{0x01, 0x00, 0x00, 0x00},
+			be: []byte{0x00, 0x00, 0x00, 0x01},
 		},
 		{
-			v: 0x0102,
-			b: []byte{0x02, 0x01, 0x00, 0x00},
+			v:  0x0102,
+			le: []byte{0x02, 0x01, 0x00, 0x00},
+			be: []byte{0x00, 0x00, 0x01, 0x02},
 		},
 		{
-			v: 0x1234,
-			b: []byte{0x34, 0x12, 0x00, 0x00},
+			v:  0x1234,
+			le: []byte{0x34, 0x12, 0x00, 0x00},
+			be: []byte{0x00, 0x00, 0x12, 0x34},
 		},
 		{
-			v: 0xffff,
-			b: []byte{0xff, 0xff, 0x00, 0x00},
+			v:  0xffff,
+			le: []byte{0xff, 0xff, 0x00, 0x00},
+			be: []byte{0x00, 0x00, 0xff, 0xff},
 		},
 		{
-			v: 0x01020304,
-			b: []byte{0x04, 0x03, 0x02, 0x01},
+			v:  0x01020304,
+			le: []byte{0x04, 0x03, 0x02, 0x01},
+			be: []byte{0x01, 0x02, 0x03, 0x04},
 		},
 		{
-			v: 0x1a2a3a4a,
-			b: []byte{0x4a, 0x3a, 0x2a, 0x1a},
+			v:  0x1a2a3a4a,
+			le: []byte{0x4a, 0x3a, 0x2a, 0x1a},
+			be: []byte{0x1a, 0x2a, 0x3a, 0x4a},
 		},
 	}
 
@@ -300,21 +311,24 @@ func TestUint32(t *testing.T) {
 			b := make([]byte, 4)
 			PutUint32(b, tt.v)
 
-			if want, got := tt.b, b; !bytes.Equal(want, got) {
+			var want []byte
+			if cpu.IsBigEndian {
+				want = tt.be
+			} else {
+				want = tt.le
+			}
+
+			if got := b; !bytes.Equal(want, got) {
 				t.Fatalf("unexpected bytes:\n- want: [%# x]\n-  got: [%# x]",
 					want, got)
 			}
 
-			v := Uint32(b)
-
-			if want, got := tt.v, v; want != got {
+			if want, got := tt.v, Uint32(b); want != got {
 				t.Fatalf("unexpected integer:\n- want: 0x%04x\n-  got: 0x%04x",
 					want, got)
 			}
 
-			b = Uint32Bytes(tt.v)
-
-			if want, got := tt.b, b; !bytes.Equal(want, got) {
+			if got := Uint32Bytes(tt.v); !bytes.Equal(want, got) {
 				t.Fatalf("unexpected bytes:\n- want: [%# x]\n-  got: [%# x]",
 					want, got)
 			}
@@ -323,42 +337,49 @@ func TestUint32(t *testing.T) {
 }
 
 func TestUint64(t *testing.T) {
-	skipBigEndian(t)
 	tests := []struct {
-		v uint64
-		b []byte
+		v      uint64
+		le, be []byte
 	}{
 		{
-			v: 0x1,
-			b: []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			v:  0x1,
+			le: []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			be: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
 		},
 		{
-			v: 0x0102,
-			b: []byte{0x02, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			v:  0x0102,
+			le: []byte{0x02, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			be: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02},
 		},
 		{
-			v: 0x1234,
-			b: []byte{0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			v:  0x1234,
+			le: []byte{0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			be: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x34},
 		},
 		{
-			v: 0xffff,
-			b: []byte{0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			v:  0xffff,
+			le: []byte{0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			be: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff},
 		},
 		{
-			v: 0x01020304,
-			b: []byte{0x04, 0x03, 0x02, 0x01, 0x00, 0x00, 0x00, 0x00},
+			v:  0x01020304,
+			le: []byte{0x04, 0x03, 0x02, 0x01, 0x00, 0x00, 0x00, 0x00},
+			be: []byte{0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04},
 		},
 		{
-			v: 0x1a2a3a4a,
-			b: []byte{0x4a, 0x3a, 0x2a, 0x1a, 0x00, 0x00, 0x00, 0x00},
+			v:  0x1a2a3a4a,
+			le: []byte{0x4a, 0x3a, 0x2a, 0x1a, 0x00, 0x00, 0x00, 0x00},
+			be: []byte{0x00, 0x00, 0x00, 0x00, 0x1a, 0x2a, 0x3a, 0x4a},
 		},
 		{
-			v: 0x0102030405060708,
-			b: []byte{0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01},
+			v:  0x0102030405060708,
+			le: []byte{0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01},
+			be: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
 		},
 		{
-			v: 0x1a2a3a4a5a6a7a8a,
-			b: []byte{0x8a, 0x7a, 0x6a, 0x5a, 0x4a, 0x3a, 0x2a, 0x1a},
+			v:  0x1a2a3a4a5a6a7a8a,
+			le: []byte{0x8a, 0x7a, 0x6a, 0x5a, 0x4a, 0x3a, 0x2a, 0x1a},
+			be: []byte{0x1a, 0x2a, 0x3a, 0x4a, 0x5a, 0x6a, 0x7a, 0x8a},
 		},
 	}
 
@@ -367,21 +388,24 @@ func TestUint64(t *testing.T) {
 			b := make([]byte, 8)
 			PutUint64(b, tt.v)
 
-			if want, got := tt.b, b; !bytes.Equal(want, got) {
+			var want []byte
+			if cpu.IsBigEndian {
+				want = tt.be
+			} else {
+				want = tt.le
+			}
+
+			if got := b; !bytes.Equal(want, got) {
 				t.Fatalf("unexpected bytes:\n- want: [%# x]\n-  got: [%# x]",
 					want, got)
 			}
 
-			v := Uint64(b)
-
-			if want, got := tt.v, v; want != got {
+			if want, got := tt.v, Uint64(b); want != got {
 				t.Fatalf("unexpected integer:\n- want: 0x%04x\n-  got: 0x%04x",
 					want, got)
 			}
 
-			b = Uint64Bytes(tt.v)
-
-			if want, got := tt.b, b; !bytes.Equal(want, got) {
+			if got := Uint64Bytes(tt.v); !bytes.Equal(want, got) {
 				t.Fatalf("unexpected bytes:\n- want: [%# x]\n-  got: [%# x]",
 					want, got)
 			}
@@ -390,42 +414,49 @@ func TestUint64(t *testing.T) {
 }
 
 func TestInt32(t *testing.T) {
-	skipBigEndian(t)
 	tests := []struct {
-		v int32
-		b []byte
+		v      int32
+		le, be []byte
 	}{
 		{
-			v: 0x1,
-			b: []byte{0x01, 0x00, 0x00, 0x00},
+			v:  0x1,
+			le: []byte{0x01, 0x00, 0x00, 0x00},
+			be: []byte{0x00, 0x00, 0x00, 0x01},
 		},
 		{
-			v: 0x0102,
-			b: []byte{0x02, 0x01, 0x00, 0x00},
+			v:  0x0102,
+			le: []byte{0x02, 0x01, 0x00, 0x00},
+			be: []byte{0x00, 0x00, 0x01, 0x02},
 		},
 		{
-			v: 0x1234,
-			b: []byte{0x34, 0x12, 0x00, 0x00},
+			v:  0x1234,
+			le: []byte{0x34, 0x12, 0x00, 0x00},
+			be: []byte{0x00, 0x00, 0x12, 0x34},
 		},
 		{
-			v: 0xffff,
-			b: []byte{0xff, 0xff, 0x00, 0x00},
+			v:  0xffff,
+			le: []byte{0xff, 0xff, 0x00, 0x00},
+			be: []byte{0x00, 0x00, 0xff, 0xff},
 		},
 		{
-			v: 0x01020304,
-			b: []byte{0x04, 0x03, 0x02, 0x01},
+			v:  0x01020304,
+			le: []byte{0x04, 0x03, 0x02, 0x01},
+			be: []byte{0x01, 0x02, 0x03, 0x04},
 		},
 		{
-			v: 0x1a2a3a4a,
-			b: []byte{0x4a, 0x3a, 0x2a, 0x1a},
+			v:  0x1a2a3a4a,
+			le: []byte{0x4a, 0x3a, 0x2a, 0x1a},
+			be: []byte{0x1a, 0x2a, 0x3a, 0x4a},
 		},
 		{
-			v: -1,
-			b: []byte{0xff, 0xff, 0xff, 0xff},
+			v:  -1,
+			le: []byte{0xff, 0xff, 0xff, 0xff},
+			be: []byte{0xff, 0xff, 0xff, 0xff},
 		},
 		{
-			v: -2,
-			b: []byte{0xfe, 0xff, 0xff, 0xff},
+			v:  -2,
+			le: []byte{0xfe, 0xff, 0xff, 0xff},
+			be: []byte{0xff, 0xff, 0xff, 0xfe},
 		},
 	}
 
@@ -434,30 +465,27 @@ func TestInt32(t *testing.T) {
 			b := make([]byte, 4)
 			PutInt32(b, tt.v)
 
-			if want, got := tt.b, b; !bytes.Equal(want, got) {
+			var want []byte
+			if cpu.IsBigEndian {
+				want = tt.be
+			} else {
+				want = tt.le
+			}
+
+			if got := b; !bytes.Equal(want, got) {
 				t.Fatalf("unexpected bytes:\n- want: [%# x]\n-  got: [%# x]",
 					want, got)
 			}
 
-			v := Int32(b)
-
-			if want, got := tt.v, v; want != got {
+			if want, got := tt.v, Int32(b); want != got {
 				t.Fatalf("unexpected integer:\n- want: 0x%04x\n-  got: 0x%04x",
 					want, got)
 			}
 
-			b = Int32Bytes(tt.v)
-
-			if want, got := tt.b, b; !bytes.Equal(want, got) {
+			if got := Int32Bytes(tt.v); !bytes.Equal(want, got) {
 				t.Fatalf("unexpected bytes:\n- want: [%# x]\n-  got: [%# x]",
 					want, got)
 			}
 		})
-	}
-}
-
-func skipBigEndian(t *testing.T) {
-	if cpu.IsBigEndian {
-		t.Skip("skipping test on big-endian system")
 	}
 }


### PR DESCRIPTION
Add distinct test fixtures for bigendian hosts to nlenc package and drop skipBigEndian function.

IMHO these tests are a little paranoid, testing and re-testing the same byte-swapping scenarios, just with different values. The number of tests cases could probably be reduced by half.

Also, I question the entire need for these functions, given that such functionality exists in the Go standard library (e.g. `binary.NativeEndian.Uint32` and friends).

Refs: #220, #227