### PR TITLE
Improve error handling

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 version: "2"
 linters:
   enable:
+    # - errorlint
     - misspell
     - modernize
     - revive

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -215,7 +215,7 @@ func TestMarshalAttributes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b, err := MarshalAttributes(tt.attrs)
 
-			if want, got := tt.err, err; want != got {
+			if want, got := tt.err, err; !errors.Is(want, got) {
 				t.Fatalf("unexpected error:\n- want: %v\n-  got: %v",
 					want, got)
 			}
@@ -395,7 +395,7 @@ func TestUnmarshalAttributes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			attrs, err := UnmarshalAttributes(tt.b)
 
-			if want, got := tt.err, err; want != got {
+			if want, got := tt.err, err; !errors.Is(want, got) {
 				t.Fatalf("unexpected error:\n- want: %v\n-  got: %v",
 					want, got)
 			}

--- a/errors.go
+++ b/errors.go
@@ -124,7 +124,8 @@ type timeout interface {
 
 // Timeout reports whether the error was caused by an I/O timeout.
 func (e *OpError) Timeout() bool {
-	if ne, ok := e.Err.(*os.SyscallError); ok {
+	ne := &os.SyscallError{}
+	if errors.As(e.Err, &ne) {
 		t, ok := ne.Err.(timeout)
 		return ok && t.Timeout()
 	}
@@ -138,7 +139,8 @@ type temporary interface {
 
 // Temporary reports whether an operation may succeed if retried.
 func (e *OpError) Temporary() bool {
-	if ne, ok := e.Err.(*os.SyscallError); ok {
+	ne := &os.SyscallError{}
+	if errors.As(e.Err, &ne) {
 		t, ok := ne.Err.(temporary)
 		return ok && t.Temporary()
 	}

--- a/message_test.go
+++ b/message_test.go
@@ -221,7 +221,7 @@ func TestMessageMarshal(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b, err := tt.m.MarshalBinary()
 
-			if want, got := tt.err, err; want != got {
+			if want, got := tt.err, err; !errors.Is(want, got) {
 				t.Fatalf("unexpected error:\n- want: %v\n-  got: %v", want, got)
 			}
 			if err != nil {
@@ -311,7 +311,7 @@ func TestMessageUnmarshal(t *testing.T) {
 			var m Message
 			err := (&m).UnmarshalBinary(tt.b)
 
-			if want, got := tt.err, err; want != got {
+			if want, got := tt.err, err; !errors.Is(want, got) {
 				t.Fatalf("unexpected error:\n- want: %v\n-  got: %v", want, got)
 			}
 			if err != nil {
@@ -467,7 +467,7 @@ func TestValidate(t *testing.T) {
 					want, got)
 			}
 
-			if want, got := tt.err, oerr.Err; want != got {
+			if want, got := tt.err, oerr.Err; !errors.Is(want, got) {
 				t.Fatalf("unexpected error:\n- want: %v\n-  got: %v",
 					want, got)
 			}

--- a/nltest/errors_unix.go
+++ b/nltest/errors_unix.go
@@ -2,9 +2,14 @@
 
 package nltest
 
-import "golang.org/x/sys/unix"
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
 
 func isSyscallError(err error) bool {
-	_, ok := err.(unix.Errno)
+	var errno unix.Errno
+	ok := errors.As(err, &errno)
 	return ok
 }

--- a/nltest/nltest.go
+++ b/nltest/nltest.go
@@ -2,6 +2,7 @@
 package nltest
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"iter"
@@ -166,29 +167,23 @@ func (c *socket) ReceiveIter() iter.Seq2[netlink.Message, error] {
 		// No messages set by Send means that we are emulating a
 		// multicast response or an error occurred.
 		if len(c.msgs) == 0 {
-			switch c.err {
-			case nil:
-				// No error, simulate multicast, but also return EOF to simulate
-				// no replies if needed.
+			switch {
+			case c.err == nil:
 				msgs, err := c.fn(nil)
-				if err == io.EOF {
-					err = nil //nolint:ineffassign
+				if errors.Is(err, io.EOF) {
 					return
 				}
-
 				if err != nil {
 					yield(netlink.Message{}, err)
 					return
 				}
-
 				for _, m := range msgs {
 					if !yield(m, nil) {
 						return
 					}
 				}
 				return
-			case io.EOF:
-				// EOF, simulate no replies in multi-part message.
+			case errors.Is(c.err, io.EOF):
 				return
 			}
 

--- a/nltest/nltest_linux_test.go
+++ b/nltest/nltest_linux_test.go
@@ -35,7 +35,7 @@ func TestLinuxSyscallError(t *testing.T) {
 	if !errors.As(err, &serr) {
 		t.Fatalf("error did not contain *os.SyscallError")
 	}
-	if serr.Err != unix.ENOENT {
+	if !errors.Is(serr.Err, unix.ENOENT) {
 		t.Fatalf("expected ENOENT, but got: %v", serr.Err)
 	}
 }


### PR DESCRIPTION
Use Go `errors` package to improve some error testing/handling.