### PR TITLE
conn_linux: copy pooled receive buffers before parsing

### DIFF
--- a/conn_linux.go
+++ b/conn_linux.go
@@ -163,6 +163,21 @@ func (c *conn) getBuffer() ([]byte, func(), error) {
 	return make([]byte, nlmsgAlign(n)), func() {}, nil
 }
 
+// ownedBuffer trims b to the aligned size of the received datagram and, when
+// using pooled buffers, copies it to memory owned by the caller.
+func (c *conn) ownedBuffer(b []byte, n int) []byte {
+	aligned := nlmsgAlign(n)
+	if c.pool == nil {
+		return b[:aligned]
+	}
+
+	// A pooled buffer may not have an aligned length. Copy the received bytes
+	// to an aligned buffer and let the zero-value tail bytes act as padding.
+	out := make([]byte, aligned)
+	copy(out, b[:n])
+	return out
+}
+
 // ReceiveIter returns an iterator over Messages received from netlink.
 func (c *conn) ReceiveIter() iter.Seq2[Message, error] {
 	return func(yield func(Message, error) bool) {
@@ -190,7 +205,7 @@ func (c *conn) ReceiveIter() iter.Seq2[Message, error] {
 			return
 		}
 
-		for msg, err := range parseMessagesIter(b[:nlmsgAlign(n)]) {
+		for msg, err := range parseMessagesIter(c.ownedBuffer(b, n)) {
 			if err != nil {
 				yield(Message{}, err)
 				return

--- a/conn_linux_integration_test.go
+++ b/conn_linux_integration_test.go
@@ -1158,6 +1158,94 @@ func TestIntegrationConnMessageBufferSize(t *testing.T) {
 	}
 }
 
+func TestIntegrationConnMessageBufferSizeCopiesMessageData(t *testing.T) {
+	t.Parallel()
+
+	c, err := netlink.Dial(unix.NETLINK_USERSOCK, &netlink.Config{
+		MessageBufferSize: 64,
+	})
+	if err != nil {
+		t.Fatalf("failed to dial netlink: %v", err)
+	}
+	defer c.Close()
+
+	pid := c.PID()
+	rc, err := c.SyscallConn()
+	if err != nil {
+		t.Fatalf("failed to get syscall conn: %v", err)
+	}
+
+	send := func(seq uint32, payload []byte) {
+		t.Helper()
+
+		const headerLen = 16
+		length := headerLen + len(payload)
+		alignedLength := (length + 3) &^ 3
+
+		b := make([]byte, alignedLength)
+		binary.NativeEndian.PutUint32(b[0:4], uint32(alignedLength))
+		binary.NativeEndian.PutUint16(b[4:6], uint16(netlink.Noop))
+		binary.NativeEndian.PutUint16(b[6:8], uint16(netlink.Request))
+		binary.NativeEndian.PutUint32(b[8:12], seq)
+		binary.NativeEndian.PutUint32(b[12:16], pid)
+		copy(b[headerLen:], payload)
+
+		var writeErr error
+		err := rc.Write(func(fd uintptr) bool {
+			addr := &unix.SockaddrNetlink{
+				Family: unix.AF_NETLINK,
+				Pid:    pid,
+			}
+			writeErr = unix.Sendto(int(fd), b, 0, addr)
+			return true
+		})
+		if err != nil {
+			t.Fatalf("rc.Write failed: %v", err)
+		}
+		if writeErr != nil {
+			t.Fatalf("failed to send message: %v", writeErr)
+		}
+	}
+
+	firstPayload := []byte{1, 1, 1, 1}
+	send(1, firstPayload)
+
+	if err := c.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("failed to set read deadline: %v", err)
+	}
+	first, err := c.Receive()
+	if err != nil {
+		t.Fatalf("failed to receive first message: %v", err)
+	}
+	if want, got := 1, len(first); want != got {
+		t.Fatalf("unexpected first message count:\n- want: %v\n-  got: %v", want, got)
+	}
+	if diff := cmp.Diff(firstPayload, first[0].Data); diff != "" {
+		t.Fatalf("unexpected first message payload (-want +got):\n%s", diff)
+	}
+
+	secondPayload := []byte{2, 2, 2, 2}
+	send(2, secondPayload)
+
+	if err := c.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("failed to set read deadline: %v", err)
+	}
+	second, err := c.Receive()
+	if err != nil {
+		t.Fatalf("failed to receive second message: %v", err)
+	}
+	if want, got := 1, len(second); want != got {
+		t.Fatalf("unexpected second message count:\n- want: %v\n-  got: %v", want, got)
+	}
+	if diff := cmp.Diff(secondPayload, second[0].Data); diff != "" {
+		t.Fatalf("unexpected second message payload (-want +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff(firstPayload, first[0].Data); diff != "" {
+		t.Fatalf("first message payload was overwritten (-want +got):\n%s", diff)
+	}
+}
+
 // TestIntegrationConnReceiveUnaligned regression test for
 // https://github.com/mdlayher/netlink/issues/279
 func TestIntegrationConnReceiveUnaligned(t *testing.T) {


### PR DESCRIPTION
## Problem
On Linux, when `Config.MessageBufferSize` is enabled, receive buffers are reused from a pool.
`Message.UnmarshalBinary` keeps `Message.Data` as a slice into the parsed input buffer, so returned messages may reference pooled memory that is reused by later receives.

This is especially visible when responses are read across multiple `recvmsg` calls (for example, multipart netlink dumps): a later receive can overwrite data from previously returned messages.

## Root cause
`ReceiveIter` parsed messages directly from the pooled receive buffer and then returned that buffer to the pool before callers were necessarily done using `Message.Data`.

## Fix
- Add `ownedBuffer` in `conn_linux.go` and parse from it in `ReceiveIter`.
- Non-pooled path: keep existing behavior (`b[:nlmsgAlign(n)]`) with no extra copy.
- Pooled path: copy `n` received bytes into a fresh aligned buffer and parse from that owned memory.

This keeps the change minimal and targeted to the pooled-buffer path only.

## Tests
Add integration regression test:
- `TestIntegrationConnMessageBufferSizeCopiesMessageData` in `conn_linux_integration_test.go`.
- Uses `NETLINK_USERSOCK` with `MessageBufferSize` enabled.
- Sends two datagrams with different payloads.
- Verifies payload from the first `Receive()` remains unchanged after the second `Receive()`.