### PR TITLE
conn: fix Receive blocking Send

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -32,6 +32,12 @@ type Conn struct {
 	// transaction within Execute.
 	mu sync.RWMutex
 
+	// receiveMu serializes concurrent Receive and ReceiveIter calls to prevent
+	// races in multi-part message handling and the peek/allocate logic in
+	// conn_linux.go. It is separate from mu so that Send can proceed
+	// concurrently with Receive.
+	receiveMu sync.Mutex
+
 	// sock is the operating system-specific implementation of
 	// a netlink sockets connection.
 	sock Socket
@@ -226,10 +232,13 @@ func (c *Conn) lockedSend(m Message) (Message, error) {
 //
 // If any of the messages indicate a netlink error, that error will be returned.
 func (c *Conn) Receive() ([]Message, error) {
-	// Wait for any concurrent calls to Execute and Receive to finish before
-	// proceeding.
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	// Wait for any concurrent calls to Execute to finish before proceeding.
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	// Serialize concurrent Receive calls. See receiveMu for details.
+	c.receiveMu.Lock()
+	defer c.receiveMu.Unlock()
 
 	return c.lockedReceive()
 }
@@ -242,8 +251,13 @@ func (c *Conn) Receive() ([]Message, error) {
 // response is multi-part, the remaining messages will be discarded.
 func (c *Conn) ReceiveIter() iter.Seq2[Message, error] {
 	return func(yield func(Message, error) bool) {
-		c.mu.Lock()
-		defer c.mu.Unlock()
+		// Wait for any concurrent calls to Execute to finish before proceeding.
+		c.mu.RLock()
+		defer c.mu.RUnlock()
+
+		// Serialize concurrent ReceiveIter calls. See receiveMu for details.
+		c.receiveMu.Lock()
+		defer c.receiveMu.Unlock()
 
 		for msg, err := range c.lockedReceiveIter() {
 			if err != nil {

--- a/conn_linux_integration_test.go
+++ b/conn_linux_integration_test.go
@@ -491,6 +491,55 @@ func TestIntegrationConnConcurrentSerializeReceiveIter(t *testing.T) {
 	}
 }
 
+// TestIntegrationConnConcurrentSendWhileReceiving verifies that Send can
+// proceed concurrently with a blocking Receive, as required by patterns like
+// NFQUEUE where one goroutine reads packets and another sends verdicts.
+func TestIntegrationConnConcurrentSendWhileReceiving(t *testing.T) {
+	t.Parallel()
+
+	c, err := netlink.Dial(unix.NETLINK_GENERIC, nil)
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+
+	// Detect deadlock: if Receive holds an exclusive lock, Send blocks until
+	// Receive returns, hanging the test indefinitely.
+	timer := time.AfterFunc(10*time.Second, func() {
+		panic("deadlock: Send blocked waiting for Receive to release its lock")
+	})
+	defer timer.Stop()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	defer wg.Wait()
+	defer c.Close()
+
+	req := netlink.Message{
+		Header: netlink.Header{
+			Flags: netlink.Request | netlink.Acknowledge,
+		},
+	}
+
+	sigC := make(chan struct{})
+	go func() {
+		defer wg.Done()
+
+		// Wait for the main goroutine to enter Receive, then give it time to
+		// block in recvmsg before attempting Send.
+		<-sigC
+		time.Sleep(50 * time.Millisecond)
+
+		if _, err := c.Send(req); err != nil {
+			panicf("Send failed while Receive was blocking: %v", err)
+		}
+
+		c.Close()
+	}()
+
+	close(sigC)
+	c.Receive()
+}
+
 func TestReceiveIter(t *testing.T) {
 	t.Parallel()
 	c, err := netlink.Dial(unix.NETLINK_GENERIC, nil)

--- a/conn_linux_integration_test.go
+++ b/conn_linux_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"iter"
 	"math/rand"
 	"net"
 	"os"
@@ -18,6 +19,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/mdlayher/netlink"
+	"github.com/mdlayher/netlink/nltest"
 	"golang.org/x/net/bpf"
 	"golang.org/x/sys/unix"
 )
@@ -491,53 +493,71 @@ func TestIntegrationConnConcurrentSerializeReceiveIter(t *testing.T) {
 	}
 }
 
-// TestIntegrationConnConcurrentSendWhileReceiving verifies that Send can
-// proceed concurrently with a blocking Receive, as required by patterns like
-// NFQUEUE where one goroutine reads packets and another sends verdicts.
-func TestIntegrationConnConcurrentSendWhileReceiving(t *testing.T) {
+// TestConnSendConcurrentWithReceive verifies that Send can proceed concurrently
+// with a blocking Receive, as required by patterns like NFQUEUE where one
+// goroutine reads packets and another sends verdicts.
+func TestConnSendConcurrentWithReceive(t *testing.T) {
 	t.Parallel()
 
-	c, err := netlink.Dial(unix.NETLINK_GENERIC, nil)
-	if err != nil {
-		t.Fatalf("failed to dial: %v", err)
+	sock := &blockingSocket{
+		receivingC: make(chan struct{}),
+		doneC:      make(chan struct{}),
 	}
 
-	// Detect deadlock: if Receive holds an exclusive lock, Send blocks until
-	// Receive returns, hanging the test indefinitely.
-	timer := time.AfterFunc(10*time.Second, func() {
-		panic("deadlock: Send blocked waiting for Receive to release its lock")
-	})
-	defer timer.Stop()
+	c := netlink.NewConn(sock, nltest.PID)
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	defer wg.Wait()
-	defer c.Close()
+	wg.Go(func() { c.Receive() })
 
-	req := netlink.Message{
-		Header: netlink.Header{
-			Flags: netlink.Request | netlink.Acknowledge,
-		},
+	// Block until ReceiveIter has entered its blocking state
+	select {
+	case <-sock.receivingC:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Receive to enter blocking state")
 	}
 
-	sigC := make(chan struct{})
+	// Send must not block while Receive is holding Conn.receiveMu
+	sendDone := make(chan error, 1)
 	go func() {
-		defer wg.Done()
-
-		// Wait for the main goroutine to enter Receive, then give it time to
-		// block in recvmsg before attempting Send.
-		<-sigC
-		time.Sleep(50 * time.Millisecond)
-
-		if _, err := c.Send(req); err != nil {
-			panicf("Send failed while Receive was blocking: %v", err)
-		}
-
-		c.Close()
+		_, err := c.Send(netlink.Message{})
+		sendDone <- err
 	}()
 
-	close(sigC)
-	c.Receive()
+	select {
+	case err := <-sendDone:
+		if err != nil {
+			t.Fatalf("Send failed: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("deadlock: Send blocked while Receive was running")
+	}
+
+	c.Close()
+	wg.Wait()
+}
+
+// blockingSocket is a netlink.Socket whose ReceiveIter blocks until Close.
+// receivingC is closed when ReceiveIter first enters its blocking state,
+// providing a deterministic synchronisation point for tests.
+type blockingSocket struct {
+	receivingOnce sync.Once
+	receivingC    chan struct{}
+	doneC         chan struct{}
+	closeOnce     sync.Once
+}
+
+func (s *blockingSocket) Close() error {
+	s.closeOnce.Do(func() { close(s.doneC) })
+	return nil
+}
+func (s *blockingSocket) Send(_ netlink.Message) error           { return nil }
+func (s *blockingSocket) SendMessages(_ []netlink.Message) error { return nil }
+func (s *blockingSocket) Receive() ([]netlink.Message, error)    { return nil, nil }
+func (s *blockingSocket) ReceiveIter() iter.Seq2[netlink.Message, error] {
+	return func(_ func(netlink.Message, error) bool) {
+		s.receivingOnce.Do(func() { close(s.receivingC) })
+		<-s.doneC
+	}
 }
 
 func TestReceiveIter(t *testing.T) {


### PR DESCRIPTION
In #265, Receive was changed from RLock to Lock to serialize concurrent Receive calls. Since Send uses RLock, it blocks for as long as Receive holds the exclusive lock. When Receive is blocking in recvmsg waiting for kernel data, Send is blocked too. This causes a deadlock in patterns like NFQUEUE, where one can goroutine read packets while another sends verdicts concurrently.

Fix by introducing a separate receiveMu that serializes concurrent Receive calls without holding mu exclusively, keeping Send and Receive concurrency compatible.

Fixes: #288