### PR TITLE
netlink: add AttributeEncoder.Len()

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -478,13 +478,23 @@ type AttributeEncoder struct {
 	// If not set, the native byte order will be used.
 	ByteOrder binary.ByteOrder
 
-	attrs []Attribute
-	err   error
+	attrs  []Attribute
+	length int
+	err    error
 }
 
 // NewAttributeEncoder creates an AttributeEncoder that encodes Attributes.
 func NewAttributeEncoder() *AttributeEncoder {
 	return &AttributeEncoder{ByteOrder: binary.NativeEndian}
+}
+
+func (ae *AttributeEncoder) push(a Attribute) {
+	if len(a.Data) > math.MaxUint16-nlaHeaderLen {
+		ae.err = errors.New("attribute data is too large to fit in a netlink attribute")
+		return
+	}
+	ae.length += nlaHeaderLen + nlaAlign(len(a.Data))
+	ae.attrs = append(ae.attrs, a)
 }
 
 // Uint8 encodes uint8 data into an Attribute specified by typ.
@@ -493,7 +503,7 @@ func (ae *AttributeEncoder) Uint8(typ uint16, v uint8) {
 		return
 	}
 
-	ae.attrs = append(ae.attrs, Attribute{
+	ae.push(Attribute{
 		Type: typ,
 		Data: []byte{v},
 	})
@@ -508,7 +518,7 @@ func (ae *AttributeEncoder) Uint16(typ uint16, v uint16) {
 	b := make([]byte, 2)
 	ae.ByteOrder.PutUint16(b, v)
 
-	ae.attrs = append(ae.attrs, Attribute{
+	ae.push(Attribute{
 		Type: typ,
 		Data: b,
 	})
@@ -523,7 +533,7 @@ func (ae *AttributeEncoder) Uint32(typ uint16, v uint32) {
 	b := make([]byte, 4)
 	ae.ByteOrder.PutUint32(b, v)
 
-	ae.attrs = append(ae.attrs, Attribute{
+	ae.push(Attribute{
 		Type: typ,
 		Data: b,
 	})
@@ -538,7 +548,7 @@ func (ae *AttributeEncoder) Uint64(typ uint16, v uint64) {
 	b := make([]byte, 8)
 	ae.ByteOrder.PutUint64(b, v)
 
-	ae.attrs = append(ae.attrs, Attribute{
+	ae.push(Attribute{
 		Type: typ,
 		Data: b,
 	})
@@ -550,7 +560,7 @@ func (ae *AttributeEncoder) Int8(typ uint16, v int8) {
 		return
 	}
 
-	ae.attrs = append(ae.attrs, Attribute{
+	ae.push(Attribute{
 		Type: typ,
 		Data: []byte{uint8(v)},
 	})
@@ -565,7 +575,7 @@ func (ae *AttributeEncoder) Int16(typ uint16, v int16) {
 	b := make([]byte, 2)
 	ae.ByteOrder.PutUint16(b, uint16(v))
 
-	ae.attrs = append(ae.attrs, Attribute{
+	ae.push(Attribute{
 		Type: typ,
 		Data: b,
 	})
@@ -580,7 +590,7 @@ func (ae *AttributeEncoder) Int32(typ uint16, v int32) {
 	b := make([]byte, 4)
 	ae.ByteOrder.PutUint32(b, uint32(v))
 
-	ae.attrs = append(ae.attrs, Attribute{
+	ae.push(Attribute{
 		Type: typ,
 		Data: b,
 	})
@@ -595,7 +605,7 @@ func (ae *AttributeEncoder) Int64(typ uint16, v int64) {
 	b := make([]byte, 8)
 	ae.ByteOrder.PutUint64(b, uint64(v))
 
-	ae.attrs = append(ae.attrs, Attribute{
+	ae.push(Attribute{
 		Type: typ,
 		Data: b,
 	})
@@ -609,7 +619,7 @@ func (ae *AttributeEncoder) Flag(typ uint16, v bool) {
 	}
 
 	// Flags have no length or data fields.
-	ae.attrs = append(ae.attrs, Attribute{Type: typ})
+	ae.push(Attribute{Type: typ})
 }
 
 // String encodes string s as a null-terminated string into an Attribute
@@ -619,13 +629,7 @@ func (ae *AttributeEncoder) String(typ uint16, s string) {
 		return
 	}
 
-	// Length checking, thanks ubiquitousbyte on GitHub.
-	if len(s) > math.MaxUint16-nlaHeaderLen {
-		ae.err = errors.New("string is too large to fit in a netlink attribute")
-		return
-	}
-
-	ae.attrs = append(ae.attrs, Attribute{
+	ae.push(Attribute{
 		Type: typ,
 		Data: nlenc.Bytes(s),
 	})
@@ -637,12 +641,7 @@ func (ae *AttributeEncoder) Bytes(typ uint16, b []byte) {
 		return
 	}
 
-	if len(b) > math.MaxUint16-nlaHeaderLen {
-		ae.err = errors.New("byte slice is too large to fit in a netlink attribute")
-		return
-	}
-
-	ae.attrs = append(ae.attrs, Attribute{
+	ae.push(Attribute{
 		Type: typ,
 		Data: b,
 	})
@@ -665,12 +664,7 @@ func (ae *AttributeEncoder) Do(typ uint16, fn func() ([]byte, error)) {
 		return
 	}
 
-	if len(b) > math.MaxUint16-nlaHeaderLen {
-		ae.err = errors.New("byte slice produced by Do is too large to fit in a netlink attribute")
-		return
-	}
-
-	ae.attrs = append(ae.attrs, Attribute{
+	ae.push(Attribute{
 		Type: typ,
 		Data: b,
 	})
@@ -695,6 +689,9 @@ func (ae *AttributeEncoder) Nested(typ uint16, fn func(nae *AttributeEncoder) er
 		return nae.Encode()
 	})
 }
+
+// Len returns the number of bytes that the encoded attributes will occupy.
+func (ae *AttributeEncoder) Len() int { return ae.length }
 
 // Encode returns the encoded bytes representing the attributes.
 func (ae *AttributeEncoder) Encode() ([]byte, error) {

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -1169,6 +1169,130 @@ func TestAttributeEncoderOK(t *testing.T) {
 	}
 }
 
+func TestAttributeEncoderLen(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(ae *AttributeEncoder)
+		want int
+	}{
+		{
+			name: "empty",
+			fn:   func(_ *AttributeEncoder) {},
+			want: 0,
+		},
+		{
+			// 4 header + 1 data, padded to 4.
+			name: "Uint8",
+			fn:   func(ae *AttributeEncoder) { ae.Uint8(1, 0xff) },
+			want: 8,
+		},
+		{
+			// 4 header + 2 data, padded to 4.
+			name: "Uint16",
+			fn:   func(ae *AttributeEncoder) { ae.Uint16(1, 0xffff) },
+			want: 8,
+		},
+		{
+			// 4 header + 4 data.
+			name: "Uint32",
+			fn:   func(ae *AttributeEncoder) { ae.Uint32(1, 0xdeadbeef) },
+			want: 8,
+		},
+		{
+			// 4 header + 8 data.
+			name: "Uint64",
+			fn:   func(ae *AttributeEncoder) { ae.Uint64(1, 0xdeadbeefcafebabe) },
+			want: 12,
+		},
+		{
+			// 4 header + 1 data, padded to 4.
+			name: "Int8",
+			fn:   func(ae *AttributeEncoder) { ae.Int8(1, -1) },
+			want: 8,
+		},
+		{
+			// 4 header + 2 data, padded to 4.
+			name: "Int16",
+			fn:   func(ae *AttributeEncoder) { ae.Int16(1, -1) },
+			want: 8,
+		},
+		{
+			// 4 header + 4 data.
+			name: "Int32",
+			fn:   func(ae *AttributeEncoder) { ae.Int32(1, -1) },
+			want: 8,
+		},
+		{
+			// 4 header + 8 data.
+			name: "Int64",
+			fn:   func(ae *AttributeEncoder) { ae.Int64(1, -1) },
+			want: 12,
+		},
+		{
+			// 4 header + 0 data.
+			name: "Flag true",
+			fn:   func(ae *AttributeEncoder) { ae.Flag(1, true) },
+			want: 4,
+		},
+		{
+			// Flag false adds nothing.
+			name: "Flag false",
+			fn:   func(ae *AttributeEncoder) { ae.Flag(1, false) },
+			want: 0,
+		},
+		{
+			// 4 header + "test\x00" (5 bytes), padded to 8.
+			name: "String",
+			fn:   func(ae *AttributeEncoder) { ae.String(1, "test") },
+			want: 12,
+		},
+		{
+			// 4 header + 3 data, padded to 4.
+			name: "Bytes",
+			fn:   func(ae *AttributeEncoder) { ae.Bytes(1, []byte{1, 2, 3}) },
+			want: 8,
+		},
+		{
+			// 4 header + 3 data, padded to 4.
+			name: "Do",
+			fn: func(ae *AttributeEncoder) {
+				ae.Do(1, func() ([]byte, error) { return []byte{1, 2, 3}, nil })
+			},
+			want: 8,
+		},
+		{
+			// Nested Uint32 (8 bytes) wrapped in outer attr: 4 header + 8 data.
+			name: "Nested",
+			fn: func(ae *AttributeEncoder) {
+				ae.Nested(1, func(nae *AttributeEncoder) error {
+					nae.Uint32(1, 42)
+					return nil
+				})
+			},
+			want: 12,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ae := NewAttributeEncoder()
+			tt.fn(ae)
+
+			if diff := cmp.Diff(tt.want, ae.Len()); diff != "" {
+				t.Fatalf("Len() mismatch (-want +got):\n%s", diff)
+			}
+
+			b, err := ae.Encode()
+			if err != nil {
+				t.Fatalf("Encode: %v", err)
+			}
+			if diff := cmp.Diff(len(b), ae.Len()); diff != "" {
+				t.Fatalf("Len() vs len(Encode()) mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func aeEndianTest(order binary.ByteOrder) func(ae *AttributeEncoder) {
 	return func(ae *AttributeEncoder) {
 		ae.ByteOrder = order


### PR DESCRIPTION
Add a Len() method that returns the total encoded byte size of all attributes appended so far, tracked via a push() helper.

Callers that batch attributes across multiple netlink messages can use this for pre-flight size checks. For example, nftables set elements must fit within the 16 bit limit of the nested attribute. I think this could also be useful for wgctrl-go which seems to split peers and IPs based on fixed limits [1].

push() also moves the overflow check which was previously duplicated across String, Bytes and Do. This also fixes a bug where String compared len(s) instead of len(nlenc.Bytes(s)).

Benchmarks against #191's proposal showed no significant difference, so the pre-computed length is not used when encoding. This can be revised later.

[1]: https://github.com/WireGuard/wgctrl-go/blob/a9ab2273dd1075ea74b88c76f8757f8b4003fcbf/internal/wglinux/configure_linux.go#L60