### PR TITLE
Fixup dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
       golang-x:
         patterns:
           - "golang.org/x/*"
-        group-by: dependency-name
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Don't group by dependency name so we get one PR for all `golang.org/x/*` updates.