### PR TITLE
netlink: extract marshalMessages for independent testing and benchmarking

### DIFF
--- a/conn_linux.go
+++ b/conn_linux.go
@@ -104,18 +104,13 @@ func newConn(s *socket.Conn, config *Config) (*conn, uint32, error) {
 
 // SendMessages serializes multiple Messages and sends them to netlink.
 func (c *conn) SendMessages(messages []Message) error {
-	var buf []byte
-	for _, m := range messages {
-		b, err := m.MarshalBinary()
-		if err != nil {
-			return err
-		}
-
-		buf = append(buf, b...)
+	buf, err := marshalMessages(messages)
+	if err != nil {
+		return err
 	}
 
 	sa := &unix.SockaddrNetlink{Family: unix.AF_NETLINK}
-	_, err := c.s.Sendmsg(context.Background(), buf, nil, sa, 0)
+	_, err = c.s.Sendmsg(context.Background(), buf, nil, sa, 0)
 	return err
 }
 

--- a/message.go
+++ b/message.go
@@ -221,6 +221,19 @@ func (m Message) MarshalBinary() ([]byte, error) {
 	return b, nil
 }
 
+// marshalMessages serializes multiple messages into a single byte slice.
+func marshalMessages(messages []Message) ([]byte, error) {
+	var buf []byte
+	for _, m := range messages {
+		b, err := m.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		buf = append(buf, b...)
+	}
+	return buf, nil
+}
+
 // UnmarshalBinary unmarshals the contents of a byte slice into a Message.
 func (m *Message) UnmarshalBinary(b []byte) error {
 	if len(b) < nlmsgHeaderLen {

--- a/message_test.go
+++ b/message_test.go
@@ -3,6 +3,7 @@ package netlink
 import (
 	"bytes"
 	"errors"
+	"math"
 	"reflect"
 	"testing"
 
@@ -743,6 +744,78 @@ func TestParseMessagesIter(t *testing.T) {
 				return errors.Is(x, y) || errors.Is(y, x)
 			})); diff != "" {
 				t.Fatalf("unexpected errors (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMarshalMessages(t *testing.T) {
+	skipBigEndian(t)
+
+	msgs := []Message{
+		{
+			Header: Header{Length: 20, Type: 1, Flags: Request, Sequence: 1},
+			Data:   []byte("msg1"),
+		},
+		{
+			Header: Header{Length: 20, Type: 2, Flags: Request, Sequence: 2},
+			Data:   []byte("msg2"),
+		},
+		{
+			Header: Header{Length: 20, Type: 3, Flags: Request, Sequence: 3},
+			Data:   []byte("msg3"),
+		},
+	}
+
+	buf, err := marshalMessages(msgs)
+	if err != nil {
+		t.Fatalf("marshalMessages: %v", err)
+	}
+
+	var got []Message
+	for m, err := range parseMessagesIter(buf) {
+		if err != nil {
+			t.Fatalf("parseMessagesIter: %v", err)
+		}
+		got = append(got, m)
+	}
+
+	if diff := cmp.Diff(msgs, got); diff != "" {
+		t.Fatalf("round-trip mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func BenchmarkMarshalMessages(b *testing.B) {
+	sizes := []struct {
+		name  string
+		count int
+	}{
+		{"1", 1},
+		{"8", 8},
+		{"64", 64},
+		{"512", 512},
+	}
+
+	dataSize := nlmsgAlign(math.MaxUint16)
+
+	for _, sz := range sizes {
+		msgs := make([]Message, sz.count)
+		for i := range msgs {
+			msgs[i] = Message{
+				Header: Header{
+					Length: uint32(nlmsgHeaderLen + dataSize),
+					Type:   1,
+					Flags:  Request,
+				},
+				Data: make([]byte, dataSize),
+			}
+		}
+
+		b.Run(sz.name, func(b *testing.B) {
+			for b.Loop() {
+				if _, err := marshalMessages(msgs); err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
SendMessages previously inlined the logic to serialize a slice of Messages into a single buffer. Extract this into a separate marshalMessages function with its own test and benchmark.

This is a first step toward investigating whether there are any benefits to optimizing the serialization path in SendMessages, as discussed in https://github.com/mdlayher/netlink/issues/254.