### PR TITLE
netlink: reduce allocations in marshalMessages

### DIFF
--- a/message.go
+++ b/message.go
@@ -210,27 +210,40 @@ func (m Message) MarshalBinary() ([]byte, error) {
 	}
 
 	b := make([]byte, ml)
+	m.marshalInto(b)
 
+	return b, nil
+}
+
+// marshalInto marshals a Message into the supplied byte slice.
+func (m Message) marshalInto(b []byte) {
 	binary.NativeEndian.PutUint32(b[0:], m.Header.Length)
 	binary.NativeEndian.PutUint16(b[4:], uint16(m.Header.Type))
 	binary.NativeEndian.PutUint16(b[6:], uint16(m.Header.Flags))
 	binary.NativeEndian.PutUint32(b[8:], m.Header.Sequence)
 	binary.NativeEndian.PutUint32(b[12:], m.Header.PID)
-	copy(b[16:], m.Data)
-
-	return b, nil
+	copy(b[nlmsgHeaderLen:], m.Data)
 }
 
 // marshalMessages serializes multiple messages into a single byte slice.
 func marshalMessages(messages []Message) ([]byte, error) {
-	var buf []byte
+	var total int
 	for _, m := range messages {
-		b, err := m.MarshalBinary()
-		if err != nil {
-			return nil, err
+		ml := nlmsgAlign(int(m.Header.Length))
+		if ml < nlmsgHeaderLen || ml != int(m.Header.Length) {
+			return nil, errIncorrectMessageLength
 		}
-		buf = append(buf, b...)
+		total += ml
 	}
+
+	buf := make([]byte, total)
+	var offset int
+	for _, m := range messages {
+		ml := nlmsgAlign(int(m.Header.Length))
+		m.marshalInto(buf[offset:])
+		offset += ml
+	}
+
 	return buf, nil
 }
 


### PR DESCRIPTION
Reduce allocations in marshalMessages by summing their sizes and then allocating a single buffer to write directly to via a new marshalInto method.
```
                       │  before       │              after                   │
                       │    sec/op     │    sec/op     vs base                │
MarshalMessages/1-12      60.35µ ±  4%   33.61µ ±  3%  -44.32% (p=0.000 n=10)
MarshalMessages/8-12     1537.5µ ±  4%   330.9µ ± 11%  -78.47% (p=0.000 n=10)
MarshalMessages/64-12    15.403m ±  5%   1.294m ±  3%  -91.60% (p=0.000 n=10)
MarshalMessages/512-12    74.14m ± 17%   11.84m ±  4%  -84.03% (p=0.000 n=10)
geomean                   3.208m         642.5µ        -79.98%

                       │  before       │              after                   │
                       │     B/op      │     B/op      vs base                │
MarshalMessages/1-12     144.00Ki ± 0%   72.00Ki ± 0%  -50.00% (p=0.000 n=10)
MarshalMessages/8-12     2760.0Ki ± 0%   520.0Ki ± 0%  -81.16% (p=0.000 n=10)
MarshalMessages/64-12    25.719Mi ± 0%   4.008Mi ± 0%  -84.42% (p=0.000 n=10)
MarshalMessages/512-12   200.43Mi ± 0%   32.01Mi ± 0%  -84.03% (p=0.000 n=10)
geomean                   6.648Mi        1.463Mi       -78.00%

                       │  before      │             after                  │
                       │  allocs/op   │ allocs/op   vs base                │
MarshalMessages/1-12       2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
MarshalMessages/8-12      15.000 ± 0%   1.000 ± 0%  -93.33% (p=0.000 n=10)
MarshalMessages/64-12     80.000 ± 0%   1.000 ± 0%  -98.75% (p=0.000 n=10)
MarshalMessages/512-12   537.000 ± 0%   1.000 ± 0%  -99.81% (p=0.000 n=10)
geomean                    33.69        1.000       -97.03%
```
See https://github.com/mdlayher/netlink/issues/254