### PR TITLE
[AI] fix: stop Execute after ACK or Done

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -123,8 +123,9 @@ func (c *Conn) Close() error {
 }
 
 // Execute sends a single Message to netlink using Send, receives one or more
-// replies using Receive, and then checks the validity of the replies against
-// the request using Validate.
+// replies, and then checks the validity of the replies against the request
+// using Validate. If the request asks for an acknowledgement, Execute receives
+// replies until it encounters an Error message with error 0 (an ACK) or Done.
 //
 // Execute acquires a lock for the duration of the function call which blocks
 // concurrent calls to Send, SendMessages, and Receive, in order to ensure
@@ -143,7 +144,7 @@ func (c *Conn) Execute(m Message) ([]Message, error) {
 		return nil, err
 	}
 
-	res, err := c.lockedReceive()
+	res, err := c.lockedReceive(req.Header.Flags&Acknowledge != 0)
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +241,7 @@ func (c *Conn) Receive() ([]Message, error) {
 	c.receiveMu.Lock()
 	defer c.receiveMu.Unlock()
 
-	return c.lockedReceive()
+	return c.lockedReceive(false)
 }
 
 // ReceiveIter returns an iterator which can be used to receive messages from
@@ -259,7 +260,7 @@ func (c *Conn) ReceiveIter() iter.Seq2[Message, error] {
 		c.receiveMu.Lock()
 		defer c.receiveMu.Unlock()
 
-		for msg, err := range c.lockedReceiveIter() {
+		for msg, err := range c.lockedReceiveIter(false) {
 			if err != nil {
 				c.debug(func(d *debugger) {
 					d.debugf(1, "recv: err: %v", err)
@@ -279,12 +280,13 @@ func (c *Conn) ReceiveIter() iter.Seq2[Message, error] {
 }
 
 // lockedReceive implements Receive, but must be called with c.mu acquired for reading.
-// We rely on the kernel to deal with concurrent reads and writes to the netlink
-// socket itself.
-func (c *Conn) lockedReceive() ([]Message, error) {
+// If waitForAck is true, it receives messages until an Error message with
+// error 0 (an ACK) or Done is encountered. We rely on the kernel to deal with
+// concurrent reads and writes to the netlink socket itself.
+func (c *Conn) lockedReceive(waitForAck bool) ([]Message, error) {
 	var msgs []Message
 
-	for m, err := range c.lockedReceiveIter() {
+	for m, err := range c.lockedReceiveIter(waitForAck) {
 		if err != nil {
 			c.debug(func(d *debugger) {
 				d.debugf(1, "recv: err: %v", err)
@@ -304,8 +306,9 @@ func (c *Conn) lockedReceive() ([]Message, error) {
 
 // lockedReceiveIter returns an iterator which can be used to receive messages
 // from netlink, but must be called with c.mu acquired for the duration of the
-// iteration.
-func (c *Conn) lockedReceiveIter() iter.Seq2[Message, error] {
+// iteration. If waitForAck is true, it receives messages until an Error
+// message with error 0 (an ACK) or Done is encountered.
+func (c *Conn) lockedReceiveIter(waitForAck bool) iter.Seq2[Message, error] {
 	return func(yield func(Message, error) bool) {
 		// NB: All non-nil errors returned from this function *must* be of type
 		// OpError in order to maintain the appropriate contract with callers of
@@ -350,6 +353,15 @@ func (c *Conn) lockedReceiveIter() iter.Seq2[Message, error] {
 				}
 
 				send(m, nil)
+
+				// An ACK can arrive after one or more data messages. checkMessage returns an
+				// error for an Error message with a nonzero error code, so any Error message
+				// here is an ACK. Stop on that ACK or Done, matching YNL's receive path.
+				// Netlink message types: https://docs.kernel.org/userspace-api/netlink/intro.html#netlink-message-types
+				// YNL receive path: https://github.com/torvalds/linux/blob/v7.1/tools/net/ynl/lib/ynl.c#L561-L612
+				if m.Header.Type == Error || m.Header.Type == Done {
+					return
+				}
 				if stopped && !more {
 					// The user has stopped iterating and there are no more messages
 					// to read.
@@ -357,7 +369,7 @@ func (c *Conn) lockedReceiveIter() iter.Seq2[Message, error] {
 				}
 			}
 
-			if !more {
+			if !more && !waitForAck {
 				return
 			}
 		}

--- a/conn_linux_integration_test.go
+++ b/conn_linux_integration_test.go
@@ -91,6 +91,126 @@ func TestIntegrationConn(t *testing.T) {
 	}
 }
 
+func TestIntegrationConntrackGetAcknowledgement(t *testing.T) {
+	skipUnprivileged(t)
+
+	const (
+		IPCTNL_MSG_CT_NEW    netlink.HeaderType = 0x100 //nolint:revive
+		IPCTNL_MSG_CT_GET    netlink.HeaderType = 0x101 //nolint:revive
+		IPCTNL_MSG_CT_DELETE netlink.HeaderType = 0x102 //nolint:revive
+	)
+
+	c, err := netlink.Dial(unix.NETLINK_NETFILTER, nil)
+	if err != nil {
+		t.Fatalf("failed to dial netfilter netlink: %v", err)
+	}
+	defer c.Close()
+
+	sourceAddress := []byte{192, 0, 2, 1}
+	destinationAddress := []byte{192, 0, 2, 2}
+	sourcePort := uint16(32768 + rand.Intn(32768))
+	destinationPort := uint16(32768 + rand.Intn(32768))
+
+	encodeTuple := func(ae *netlink.AttributeEncoder, sourceAddress, destinationAddress []byte, sourcePort, destinationPort uint16) error {
+		ae.Nested(1, func(nae *netlink.AttributeEncoder) error {
+			nae.Bytes(1, sourceAddress)
+			nae.Bytes(2, destinationAddress)
+			return nil
+		})
+		ae.Nested(2, func(nae *netlink.AttributeEncoder) error {
+			nae.Uint8(1, unix.IPPROTO_UDP)
+			nae.Uint16(2, sourcePort)
+			nae.Uint16(3, destinationPort)
+			return nil
+		})
+		return nil
+	}
+
+	encode := func(original, reply bool, timeout uint32) []byte {
+		ae := netlink.NewAttributeEncoder()
+		ae.ByteOrder = binary.BigEndian
+		if original {
+			ae.Nested(1, func(nae *netlink.AttributeEncoder) error {
+				return encodeTuple(nae, sourceAddress, destinationAddress, sourcePort, destinationPort)
+			})
+		}
+		if reply {
+			ae.Nested(2, func(nae *netlink.AttributeEncoder) error {
+				return encodeTuple(nae, destinationAddress, sourceAddress, destinationPort, sourcePort)
+			})
+		}
+		if timeout != 0 {
+			ae.Uint32(7, timeout)
+		}
+
+		attrs, err := ae.Encode()
+		if err != nil {
+			t.Fatalf("failed to encode conntrack attributes: %v", err)
+		}
+
+		return append([]byte{unix.AF_INET, 0, 0, 0}, attrs...)
+	}
+
+	_, err = c.Execute(netlink.Message{
+		Header: netlink.Header{
+			Type:  IPCTNL_MSG_CT_NEW,
+			Flags: netlink.Request | netlink.Acknowledge | netlink.Create | netlink.Excl,
+		},
+		Data: encode(true, true, 30),
+	})
+	if err != nil {
+		t.Fatalf("failed to create conntrack entry: %v", err)
+	}
+
+	defer func() {
+		if err := c.SetReadDeadline(time.Time{}); err != nil {
+			t.Errorf("failed to reset read deadline: %v", err)
+			return
+		}
+		_, err := c.Execute(netlink.Message{
+			Header: netlink.Header{
+				Type:  IPCTNL_MSG_CT_DELETE,
+				Flags: netlink.Request | netlink.Acknowledge,
+			},
+			Data: encode(true, false, 0),
+		})
+		if err != nil {
+			t.Errorf("failed to delete conntrack entry: %v", err)
+		}
+	}()
+
+	if err := c.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("failed to set read deadline: %v", err)
+	}
+
+	msgs, err := c.Execute(netlink.Message{
+		Header: netlink.Header{
+			Type:  IPCTNL_MSG_CT_GET,
+			Flags: netlink.Request | netlink.Acknowledge,
+		},
+		Data: encode(false, true, 0),
+	})
+	if err != nil {
+		t.Fatalf("failed to get conntrack entry: %v", err)
+	}
+
+	if want, got := 2, len(msgs); want != got {
+		t.Fatalf("unexpected message count:\n- want: %v\n-  got: %v", want, got)
+	}
+	if want, got := IPCTNL_MSG_CT_NEW, msgs[0].Header.Type; want != got {
+		t.Fatalf("unexpected conntrack reply type:\n- want: %v\n-  got: %v", want, got)
+	}
+	if msgs[0].Header.Flags&netlink.Multi == 0 {
+		t.Fatalf("conntrack reply does not have multi flag: %v", msgs[0].Header.Flags)
+	}
+	if want, got := netlink.Error, msgs[1].Header.Type; want != got {
+		t.Fatalf("unexpected acknowledgement type:\n- want: %v\n-  got: %v", want, got)
+	}
+	if msgs[1].Header.Flags&netlink.Multi != 0 {
+		t.Fatalf("acknowledgement has multi flag: %v", msgs[1].Header.Flags)
+	}
+}
+
 func TestIntegrationConnConcurrentManyConns(t *testing.T) {
 	t.Parallel()
 	skipShort(t)

--- a/conn_test.go
+++ b/conn_test.go
@@ -124,6 +124,159 @@ func TestConnExecuteMultipart(t *testing.T) {
 	}
 }
 
+func TestConnExecuteAcknowledgementAfterReply(t *testing.T) {
+	const sequence = 1
+
+	req := netlink.Message{
+		Header: netlink.Header{
+			Flags:    netlink.Request | netlink.Acknowledge,
+			Sequence: sequence,
+		},
+	}
+
+	replies := []netlink.Message{
+		{
+			Header: netlink.Header{
+				Sequence: sequence,
+				PID:      1,
+			},
+			Data: []byte{0xff},
+		},
+		{
+			Header: netlink.Header{
+				Type:     netlink.Error,
+				Sequence: sequence,
+				PID:      1,
+			},
+			Data: make([]byte, 4),
+		},
+	}
+
+	var received bool
+	c := nltest.Dial(func(reqs []netlink.Message) ([]netlink.Message, error) {
+		if len(reqs) != 0 {
+			return replies[:1], nil
+		}
+		if received {
+			return nil, errors.New("unexpected extra receive")
+		}
+
+		received = true
+		return replies[1:], nil
+	})
+	defer c.Close()
+
+	got, err := c.Execute(req)
+	if err != nil {
+		t.Fatalf("failed to execute: %v", err)
+	}
+
+	if diff := cmp.Diff(replies, got); diff != "" {
+		t.Fatalf("unexpected replies (-want +got):\n%s", diff)
+	}
+}
+
+func TestConnExecuteDoneAfterReply(t *testing.T) {
+	const sequence = 1
+
+	// Some do operations use netlink.Done as their terminal response.
+	// Netlink message types: https://docs.kernel.org/userspace-api/netlink/intro.html#netlink-message-types
+	req := netlink.Message{
+		Header: netlink.Header{
+			Flags:    netlink.Request | netlink.Acknowledge,
+			Sequence: sequence,
+		},
+	}
+
+	replies := []netlink.Message{
+		{
+			Header: netlink.Header{
+				Sequence: sequence,
+				PID:      1,
+			},
+			Data: []byte{0xff},
+		},
+		{
+			Header: netlink.Header{
+				Type:     netlink.Done,
+				Sequence: sequence,
+				PID:      1,
+			},
+		},
+	}
+
+	var received bool
+	c := nltest.Dial(func(reqs []netlink.Message) ([]netlink.Message, error) {
+		if len(reqs) != 0 {
+			return replies[:1], nil
+		}
+		if received {
+			return nil, errors.New("unexpected extra receive")
+		}
+
+		received = true
+		return replies[1:], nil
+	})
+	defer c.Close()
+
+	got, err := c.Execute(req)
+	if err != nil {
+		t.Fatalf("failed to execute: %v", err)
+	}
+
+	if diff := cmp.Diff(replies, got); diff != "" {
+		t.Fatalf("unexpected replies (-want +got):\n%s", diff)
+	}
+}
+
+func TestConnExecuteMultipartAcknowledgement(t *testing.T) {
+	const sequence = 1
+
+	req := netlink.Message{
+		Header: netlink.Header{
+			Flags:    netlink.Request | netlink.Acknowledge,
+			Sequence: sequence,
+		},
+	}
+
+	replies := []netlink.Message{
+		{
+			Header: netlink.Header{
+				Flags:    netlink.Multi,
+				Sequence: sequence,
+				PID:      1,
+			},
+			Data: []byte{0xff},
+		},
+		{
+			Header: netlink.Header{
+				Type:     netlink.Error,
+				Sequence: sequence,
+				PID:      1,
+			},
+			Data: make([]byte, 4),
+		},
+	}
+
+	c := nltest.Dial(func(reqs []netlink.Message) ([]netlink.Message, error) {
+		if len(reqs) == 0 {
+			return nil, errors.New("unexpected extra receive")
+		}
+
+		return replies, nil
+	})
+	defer c.Close()
+
+	got, err := c.Execute(req)
+	if err != nil {
+		t.Fatalf("failed to execute: %v", err)
+	}
+
+	if diff := cmp.Diff(replies, got); diff != "" {
+		t.Fatalf("unexpected replies (-want +got):\n%s", diff)
+	}
+}
+
 func TestConnExecuteNoMessages(t *testing.T) {
 	c := nltest.Dial(func(_ []netlink.Message) ([]netlink.Message, error) {
 		return nil, io.EOF


### PR DESCRIPTION
Execute could wait forever when conntrack sent a Multi reply followed by an ACK without Done.

For requests with Acknowledge, keep receiving until ACK or Done, following kernel YNL behavior.


Notes: 
- AI wrote the commit with my steering. Assume the absolute worst.
- Some tests in github.com/mdlayher/ethtool will fail with this commit as those tests don't mock `Error (0)` .
- I ran this commit(all tests) against all kernel versions since v5.0, all pass except the cleanup fails on v5.0 due to a missing bugfix in the kernel release